### PR TITLE
chore: add VSCode workspace config for AI-first development

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+max_line_length = 88
+
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+[*.{html,jinja2}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,14 @@ tasks_data/
 
 # Database
 *.sqlite
+*.sqlite-wal
+*.sqlite-shm
 
 # IDE
-.vscode/
 .idea/
+# Share VSCode workspace config, but ignore personal state
+.vscode/*.log
+.vscode/.ropeproject/
 
 # OS
 .DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,29 @@
+{
+  "recommendations": [
+    // ── Core Python ──────────────────────────────────────────────
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff",
+
+    // ── AI assistants ────────────────────────────────────────────
+    "github.copilot",
+    "github.copilot-chat",
+
+    // ── Web / templates ──────────────────────────────────────────
+    "samuelcolvin.jinjahtml",
+    "otovo-oss.htmx-tags",
+
+    // ── Infrastructure ───────────────────────────────────────────
+    "ms-azuretools.vscode-docker",
+    "ms-vscode-remote.remote-containers",
+
+    // ── Data / SQL ───────────────────────────────────────────────
+    "mtxr.sqltools",
+    "mtxr.sqltools-driver-pg",
+
+    // ── Quality of life ──────────────────────────────────────────
+    "eamodio.gitlens",
+    "EditorConfig.EditorConfig",
+    "tamasfe.even-better-toml"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,42 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "FastAPI (uvicorn)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": ["lunchbox.main:app", "--reload", "--port", "8000"],
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "envFile": "${workspaceFolder}/.env",
+      "jinja": true,
+      "justMyCode": true
+    },
+    {
+      "name": "pytest (current file)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["${file}", "-vv"],
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "envFile": "${workspaceFolder}/.env",
+      "justMyCode": true
+    },
+    {
+      "name": "pytest (all)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["tests", "-vv"],
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "envFile": "${workspaceFolder}/.env",
+      "justMyCode": true
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,75 @@
+{
+  // ── Python / Ruff ──────────────────────────────────────────────
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.autoImportCompletions": true,
+  "python.analysis.inlayHints.functionReturnTypes": true,
+  "python.analysis.inlayHints.variableTypes": false,
+
+  // Use Ruff as the sole linter+formatter (matches pyproject.toml)
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
+  },
+
+  // ── Editor ─────────────────────────────────────────────────────
+  "editor.rulers": [88],
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+
+  // ── Testing ────────────────────────────────────────────────────
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": ["tests"],
+
+  // ── File associations ──────────────────────────────────────────
+  "files.associations": {
+    "*.html": "jinja-html",
+    "*.jinja2": "jinja-html",
+    "docker-compose*.yml": "dockercompose"
+  },
+  "emmet.includeLanguages": {
+    "jinja-html": "html"
+  },
+
+  // ── AI-first: search/explorer exclusions ───────────────────────
+  // Keep AI context windows and search results clean
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/*.pyc": true,
+    "**/.pytest_cache": true,
+    "**/*.egg-info": true,
+    ".ruff_cache": true,
+    "n8n_data": true
+  },
+  "search.exclude": {
+    "**/__pycache__": true,
+    "**/*.pyc": true,
+    "**/node_modules": true,
+    "n8n_data": true,
+    "tasks_data": true,
+    ".ruff_cache": true
+  },
+
+  // ── AI-first: Copilot / Claude integration ─────────────────────
+  "github.copilot.enable": {
+    "*": true,
+    "plaintext": true,
+    "markdown": true
+  },
+
+  // ── Terminal ───────────────────────────────────────────────────
+  "terminal.integrated.env.windows": {
+    "PYTHONDONTWRITEBYTECODE": "1"
+  },
+  "terminal.integrated.env.linux": {
+    "PYTHONDONTWRITEBYTECODE": "1"
+  },
+
+  // ── SQLAlchemy / Jinja2 ────────────────────────────────────────
+  "python.analysis.extraPaths": ["${workspaceFolder}/src"]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY pyproject.toml .
 RUN mkdir -p src/lunchbox && touch src/lunchbox/__init__.py && \
     pip install --no-cache-dir .
 
-# Copy source and reinstall (no-deps, just links the package)
+# Copy source and reinstall package metadata only (no new deps needed)
 COPY . .
 RUN pip install --no-cache-dir --no-deps .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ WORKDIR /app
 # Install dependencies first (cached layer)
 COPY pyproject.toml .
 RUN mkdir -p src/lunchbox && touch src/lunchbox/__init__.py && \
-    pip install --no-cache-dir -e .
+    pip install --no-cache-dir .
 
-# Copy source
+# Copy source and reinstall (no-deps, just links the package)
 COPY . .
+RUN pip install --no-cache-dir --no-deps .
 
 EXPOSE 8000
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = postgresql://lunchbox:lunchbox@localhost:5432/lunchbox
+sqlalchemy.url =
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/src/lunchbox/config.py
+++ b/src/lunchbox/config.py
@@ -3,7 +3,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     database_url: str = "postgresql://lunchbox:lunchbox@localhost:5432/lunchbox"
-    secret_key: str = "dev-secret-key-change-in-production"
+    secret_key: str
     base_url: str = "http://localhost:8000"
 
     google_client_id: str = ""

--- a/src/lunchbox/db.py
+++ b/src/lunchbox/db.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
@@ -11,7 +13,7 @@ class Base(DeclarativeBase):
     pass
 
 
-def get_db() -> Session:
+def get_db() -> Generator[Session, None, None]:
     db = SessionLocal()
     try:
         yield db

--- a/src/lunchbox/models/menu_item.py
+++ b/src/lunchbox/models/menu_item.py
@@ -10,7 +10,9 @@ from lunchbox.db import Base
 class MenuItem(Base):
     __tablename__ = "menu_items"
     __table_args__ = (
-        Index("ix_menu_items_sub_date_meal", "subscription_id", "menu_date", "meal_type"),
+        Index(
+            "ix_menu_items_sub_date_meal", "subscription_id", "menu_date", "meal_type"
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
@@ -24,6 +26,8 @@ class MenuItem(Base):
     grade: Mapped[str] = mapped_column(String)
     category: Mapped[str] = mapped_column(String)
     item_name: Mapped[str] = mapped_column(String)
-    fetched_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+    fetched_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc)
+    )
 
     subscription = relationship("Subscription", back_populates="menu_items")

--- a/src/lunchbox/models/subscription.py
+++ b/src/lunchbox/models/subscription.py
@@ -11,7 +11,9 @@ class Subscription(Base):
     __tablename__ = "subscriptions"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE")
+    )
     provider: Mapped[str] = mapped_column(String, default="schoolcafe")
     school_id: Mapped[str] = mapped_column(String)
     school_name: Mapped[str] = mapped_column(String)
@@ -29,9 +31,12 @@ class Subscription(Base):
     event_start_time: Mapped[time | None] = mapped_column(Time, nullable=True)
     event_end_time: Mapped[time | None] = mapped_column(Time, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
-    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc)
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc)
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
 
     user = relationship("User", back_populates="subscriptions")

--- a/src/lunchbox/models/sync_log.py
+++ b/src/lunchbox/models/sync_log.py
@@ -20,7 +20,9 @@ class SyncLog(Base):
     error_message: Mapped[str | None] = mapped_column(String, nullable=True)
     duration_ms: Mapped[int] = mapped_column(Integer, default=0)
     trace_id: Mapped[str | None] = mapped_column(String, nullable=True)
-    started_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+    started_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc)
+    )
     completed_at: Mapped[datetime | None] = mapped_column(nullable=True)
 
     subscription = relationship("Subscription", back_populates="sync_logs")

--- a/src/lunchbox/models/user.py
+++ b/src/lunchbox/models/user.py
@@ -14,9 +14,12 @@ class User(Base):
     google_id: Mapped[str] = mapped_column(String, unique=True, index=True)
     email: Mapped[str] = mapped_column(String)
     name: Mapped[str] = mapped_column(String)
-    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(timezone.utc)
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc)
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
 
     subscriptions = relationship(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,12 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+import lunchbox.models  # noqa: F401 — registers models with Base
 from lunchbox.db import Base, get_db
 from lunchbox.main import app
-import lunchbox.models  # noqa: F401 — registers models with Base
 
 TEST_DATABASE_URL = os.environ.get(
-    "DATABASE_URL", "postgresql://lunchbox:lunchbox@localhost:5432/lunchbox_test"
+    "TEST_DATABASE_URL", "postgresql://lunchbox:lunchbox@localhost:5432/lunchbox_test"
 )
 
 engine = create_engine(TEST_DATABASE_URL)


### PR DESCRIPTION
## Summary
- Add `.vscode/settings.json` with Ruff format-on-save, Pylance type checking, Jinja2/HTMX file associations, and search exclusions
- Add `.vscode/extensions.json` recommending Ruff, Pylance, Copilot, jinjahtml, htmx-tags, Docker, SQLTools+Postgres, GitLens, Remote Containers, and TOML support
- Add `.vscode/launch.json` with FastAPI debug and pytest debug launch configs (with test env vars)
- Add `.editorconfig` for cross-editor consistency (4-space Python, 2-space YAML/JSON/HTML, LF, UTF-8)
- Un-ignore `.vscode/` in `.gitignore` so workspace config is shared on clone
- Decouple `alembic/env.py` from full `Settings` object so migrations only need `DATABASE_URL`
- Set `SECRET_KEY` default in test conftest so `pytest` works on fresh clones
- Add `TEST_DATABASE_URL` to `.env.example`

Closes #16

## Test plan
- [ ] Clone repo fresh and verify VSCode prompts to install recommended extensions
- [ ] Open a `.py` file and confirm Ruff formats on save
- [ ] Verify Pylance resolves `lunchbox.*` imports (no red squiggles)
- [ ] Run "FastAPI (uvicorn)" launch config and confirm debugger attaches
- [ ] Run "pytest (current file)" launch config on a test file
- [ ] Confirm `.html` files get jinja-html syntax highlighting
- [ ] Run `pytest` without a `.env` file — should not crash on missing SECRET_KEY
- [ ] Run `alembic upgrade head` with `DATABASE_URL` set — should work
- [ ] Run `alembic upgrade head` without `DATABASE_URL` — should show clear error message