### PR TITLE
fix: address PR #15 review findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ POSTGRES_PASSWORD=changeme
 SECRET_KEY=changeme-generate-with-python-c-import-secrets-secrets.token_hex-32
 BASE_URL=http://localhost:8000
 
+# Test database (pytest only)
+TEST_DATABASE_URL=postgresql://lunchbox:lunchbox@localhost:5432/lunchbox_test
+
 # Google OAuth (login only — openid, email, profile scopes)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,9 +21,10 @@
       "module": "pytest",
       "args": ["${file}", "-vv"],
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/src"
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "SECRET_KEY": "test-secret-key-not-for-production",
+        "TEST_DATABASE_URL": "postgresql://lunchbox:lunchbox@localhost:5432/lunchbox_test"
       },
-      "envFile": "${workspaceFolder}/.env",
       "justMyCode": true
     },
     {
@@ -33,9 +34,10 @@
       "module": "pytest",
       "args": ["tests", "-vv"],
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/src"
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "SECRET_KEY": "test-secret-key-not-for-production",
+        "TEST_DATABASE_URL": "postgresql://lunchbox:lunchbox@localhost:5432/lunchbox_test"
       },
-      "envFile": "${workspaceFolder}/.env",
       "justMyCode": true
     }
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   // ── Python / Ruff ──────────────────────────────────────────────
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.analysis.typeCheckingMode": "basic",
   "python.analysis.autoImportCompletions": true,
   "python.analysis.inlayHints.functionReturnTypes": true,
@@ -70,6 +70,6 @@
     "PYTHONDONTWRITEBYTECODE": "1"
   },
 
-  // ── SQLAlchemy / Jinja2 ────────────────────────────────────────
+  // ── Pylance / import resolution ────────────────────────────────
   "python.analysis.extraPaths": ["${workspaceFolder}/src"]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY pyproject.toml .
 RUN mkdir -p src/lunchbox && touch src/lunchbox/__init__.py && \
     pip install --no-cache-dir .
 
-# Copy source and reinstall package metadata only (no new deps needed)
+# Copy source and reinstall without re-fetching deps (layer caching optimization)
 COPY . .
 RUN pip install --no-cache-dir --no-deps .
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,14 +1,22 @@
+import os
 from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from lunchbox.config import settings
 from lunchbox.db import Base
 import lunchbox.models  # noqa: F401 — registers models with Base
 
 config = context.config
-config.set_main_option("sqlalchemy.url", settings.database_url)
+
+# Read DATABASE_URL directly so migrations don't require SECRET_KEY or other app settings
+database_url = os.environ.get("DATABASE_URL") or config.get_main_option("sqlalchemy.url")
+if not database_url:
+    raise RuntimeError(
+        "DATABASE_URL is not set and sqlalchemy.url in alembic.ini is empty. "
+        "Set DATABASE_URL in your environment or copy .env.example to .env."
+    )
+config.set_main_option("sqlalchemy.url", database_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/src/lunchbox/sync/engine.py
+++ b/src/lunchbox/sync/engine.py
@@ -1,0 +1,132 @@
+import logging
+import time
+from datetime import date, timedelta
+
+from sqlalchemy.orm import Session
+
+from lunchbox.models import MenuItem, Subscription, SyncLog
+from lunchbox.sync.menu_client import SchoolCafeClient
+
+logger = logging.getLogger(__name__)
+
+
+def get_sync_dates(
+    days: int, skip_weekends: bool, start: date | None = None
+) -> list[date]:
+    """Generate list of dates to sync, optionally skipping weekends."""
+    start = start or date.today()
+    dates = []
+    current = start
+    while len(dates) < days:
+        if not skip_weekends or current.weekday() < 5:
+            dates.append(current)
+        current += timedelta(days=1)
+    return dates
+
+
+def sync_subscription(
+    db: Session,
+    subscription: Subscription,
+    client: SchoolCafeClient,
+    days: int = 7,
+    skip_weekends: bool = True,
+) -> SyncLog:
+    """Sync menu data for a single subscription."""
+    started_at = time.time()
+    dates = get_sync_dates(days, skip_weekends)
+    total_items = 0
+    errors = []
+
+    for sync_date in dates:
+        for meal_config in subscription.meal_configs:
+            meal_type = meal_config["meal_type"]
+            serving_line = meal_config["serving_line"]
+
+            try:
+                items = client.get_daily_menu(
+                    school_id=subscription.school_id,
+                    menu_date=sync_date,
+                    meal_type=meal_type,
+                    serving_line=serving_line,
+                    grade=subscription.grade,
+                )
+
+                # Delete existing items for this date+meal (upsert strategy)
+                db.query(MenuItem).filter(
+                    MenuItem.subscription_id == subscription.id,
+                    MenuItem.menu_date == sync_date,
+                    MenuItem.meal_type == meal_type,
+                ).delete()
+
+                # Insert fresh items
+                for item in items:
+                    db.add(
+                        MenuItem(
+                            subscription_id=subscription.id,
+                            school_id=subscription.school_id,
+                            menu_date=sync_date,
+                            meal_type=meal_type,
+                            serving_line=serving_line,
+                            grade=subscription.grade,
+                            category=item.category,
+                            item_name=item.item_name,
+                        )
+                    )
+
+                total_items += len(items)
+
+            except Exception as e:
+                logger.error(
+                    "Failed to sync %s %s for %s: %s",
+                    meal_type,
+                    sync_date,
+                    subscription.display_name,
+                    e,
+                )
+                errors.append(f"{meal_type} {sync_date}: {e}")
+
+    duration_ms = int((time.time() - started_at) * 1000)
+
+    total_expected = len(dates) * len(subscription.meal_configs)
+    if errors:
+        status = "error" if len(errors) == total_expected else "partial"
+    else:
+        status = "success"
+
+    log = SyncLog(
+        subscription_id=subscription.id,
+        status=status,
+        dates_synced=len(dates),
+        items_fetched=total_items,
+        error_message="; ".join(errors) if errors else None,
+        duration_ms=duration_ms,
+    )
+    db.add(log)
+    db.commit()
+
+    return log
+
+
+def sync_all(
+    db: Session,
+    client: SchoolCafeClient,
+    days: int = 7,
+    skip_weekends: bool = True,
+):
+    """Sync all active subscriptions."""
+    subscriptions = (
+        db.query(Subscription).filter(Subscription.is_active.is_(True)).all()
+    )
+
+    for sub in subscriptions:
+        logger.info("Syncing %s", sub.display_name)
+        try:
+            log = sync_subscription(db, sub, client, days, skip_weekends)
+            logger.info(
+                "Sync complete: %s — %s, %d items",
+                sub.display_name,
+                log.status,
+                log.items_fetched,
+            )
+        except Exception:
+            logger.exception("Sync failed for %s", sub.display_name)

--- a/src/lunchbox/sync/engine.py
+++ b/src/lunchbox/sync/engine.py
@@ -38,7 +38,7 @@ def sync_subscription(
     errors = []
 
     for sync_date in dates:
-        for meal_config in subscription.meal_configs:
+        for meal_config in subscription.meal_configs or []:
             meal_type = meal_config["meal_type"]
             serving_line = meal_config["serving_line"]
 
@@ -51,27 +51,32 @@ def sync_subscription(
                     grade=subscription.grade,
                 )
 
-                # Delete existing items for this date+meal (upsert strategy)
-                db.query(MenuItem).filter(
-                    MenuItem.subscription_id == subscription.id,
-                    MenuItem.menu_date == sync_date,
-                    MenuItem.meal_type == meal_type,
-                ).delete()
+                # Savepoint so DB errors don't corrupt the session
+                nested = db.begin_nested()
+                try:
+                    db.query(MenuItem).filter(
+                        MenuItem.subscription_id == subscription.id,
+                        MenuItem.menu_date == sync_date,
+                        MenuItem.meal_type == meal_type,
+                    ).delete()
 
-                # Insert fresh items
-                for item in items:
-                    db.add(
-                        MenuItem(
-                            subscription_id=subscription.id,
-                            school_id=subscription.school_id,
-                            menu_date=sync_date,
-                            meal_type=meal_type,
-                            serving_line=serving_line,
-                            grade=subscription.grade,
-                            category=item.category,
-                            item_name=item.item_name,
+                    for item in items:
+                        db.add(
+                            MenuItem(
+                                subscription_id=subscription.id,
+                                school_id=subscription.school_id,
+                                menu_date=sync_date,
+                                meal_type=meal_type,
+                                serving_line=serving_line,
+                                grade=subscription.grade,
+                                category=item.category,
+                                item_name=item.item_name,
+                            )
                         )
-                    )
+                    nested.commit()
+                except Exception:
+                    nested.rollback()
+                    raise
 
                 total_items += len(items)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
 import os
 
+# Set test defaults before any lunchbox imports (Settings() runs at import time)
+os.environ.setdefault("SECRET_KEY", "test-secret-key-not-for-production")
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine

--- a/tests/unit/test_sync_engine.py
+++ b/tests/unit/test_sync_engine.py
@@ -1,0 +1,93 @@
+from datetime import date
+from unittest.mock import MagicMock
+
+from lunchbox.models import MenuItem, Subscription, User
+from lunchbox.sync.engine import get_sync_dates, sync_subscription
+from lunchbox.sync.providers import MenuItemData
+
+
+class TestGetSyncDates:
+    def test_basic(self):
+        dates = get_sync_dates(3, skip_weekends=False, start=date(2026, 3, 16))
+        assert len(dates) == 3
+        assert dates[0] == date(2026, 3, 16)
+
+    def test_skip_weekends(self):
+        # 2026-03-14 is a Saturday
+        dates = get_sync_dates(3, skip_weekends=True, start=date(2026, 3, 14))
+        for d in dates:
+            assert d.weekday() < 5  # Mon-Fri
+
+    def test_returns_requested_count(self):
+        dates = get_sync_dates(5, skip_weekends=True, start=date(2026, 3, 16))
+        assert len(dates) == 5
+
+
+class TestSyncSubscription:
+    def test_successful_sync(self, db):
+        user = User(google_id="sync-test", email="t@t.com", name="T")
+        db.add(user)
+        db.flush()
+
+        sub = Subscription(
+            user_id=user.id,
+            school_id="test-school",
+            school_name="Test School",
+            grade="05",
+            meal_configs=[
+                {"meal_type": "Lunch", "serving_line": "Traditional", "sort_order": 0}
+            ],
+            display_name="Test School",
+        )
+        db.add(sub)
+        db.flush()
+
+        mock_client = MagicMock()
+        mock_client.get_daily_menu.return_value = [
+            MenuItemData(category="Entrees", item_name="Pizza"),
+            MenuItemData(category="Fruits", item_name="Apple"),
+        ]
+
+        log = sync_subscription(db, sub, mock_client, days=2, skip_weekends=False)
+
+        assert log.status == "success"
+        assert log.items_fetched == 4  # 2 items x 2 days
+        assert log.dates_synced == 2
+
+        items = db.query(MenuItem).filter(MenuItem.subscription_id == sub.id).all()
+        assert len(items) == 4
+
+    def test_partial_failure(self, db):
+        user = User(google_id="sync-partial", email="t@t.com", name="T")
+        db.add(user)
+        db.flush()
+
+        sub = Subscription(
+            user_id=user.id,
+            school_id="test-school",
+            school_name="Test School",
+            grade="05",
+            meal_configs=[
+                {"meal_type": "Lunch", "serving_line": "Traditional", "sort_order": 0}
+            ],
+            display_name="Test School",
+        )
+        db.add(sub)
+        db.flush()
+
+        mock_client = MagicMock()
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("API down")
+            return [MenuItemData(category="Entrees", item_name="Burger")]
+
+        mock_client.get_daily_menu.side_effect = side_effect
+
+        log = sync_subscription(db, sub, mock_client, days=2, skip_weekends=False)
+
+        assert log.status == "partial"
+        assert log.error_message is not None


### PR DESCRIPTION
## Summary
- Set `SECRET_KEY` default in `conftest.py` before lunchbox imports so `pytest` works on fresh clones without a `.env` file
- Decouple `alembic/env.py` from full `Settings` object; read `DATABASE_URL` directly with clear `RuntimeError` when missing
- Fix VSCode interpreter path to cross-platform `${workspaceFolder}/.venv`
- Fix Dockerfile comment accuracy ("layer caching optimization" not "metadata only")
- Add `SECRET_KEY` + `TEST_DATABASE_URL` to pytest launch configs, remove `envFile` to avoid `.env`/conftest mismatch
- Add `TEST_DATABASE_URL` to `.env.example`
- Fix `settings.json` section header from "SQLAlchemy / Jinja2" to "Pylance / import resolution"

Closes #16

## Test plan
- [ ] Run `pytest` without a `.env` file — should not crash on missing `SECRET_KEY`
- [ ] Run `alembic upgrade head` with `DATABASE_URL` set — should work
- [ ] Run `alembic upgrade head` without `DATABASE_URL` — should show clear error message
- [ ] Open project in VSCode on Windows — interpreter path should resolve correctly
- [ ] Run pytest via VSCode debugger — should use test DB URL, not production