### PR TITLE
feat: add iCal feed endpoint

### DIFF
--- a/src/lunchbox/api/feeds.py
+++ b/src/lunchbox/api/feeds.py
@@ -64,6 +64,7 @@ def _build_calendar(subscription: Subscription, items: list[MenuItem]) -> Calend
         event = Event()
         event.add("summary", summary)
         event.add("description", "\n".join(description_parts))
+        # TODO: support timed events when subscription.event_type == "timed"
         event.add("dtstart", menu_date)
         # All-day events: DTEND is exclusive, so next day
         event.add("dtend", menu_date + timedelta(days=1))
@@ -87,11 +88,11 @@ def _build_calendar(subscription: Subscription, items: list[MenuItem]) -> Calend
 
 
 @router.get("/cal/{feed_token}.ics")
-def get_feed(feed_token: str, db: Session = Depends(get_db)):
+def get_feed(feed_token: str, db: Session = Depends(get_db)) -> Response:
     try:
         token_uuid = uuid.UUID(feed_token)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Feed not found")
+        raise HTTPException(status_code=404, detail="Feed not found") from None
 
     subscription = (
         db.query(Subscription)

--- a/src/lunchbox/api/feeds.py
+++ b/src/lunchbox/api/feeds.py
@@ -1,0 +1,131 @@
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from icalendar import Alarm, Calendar, Event
+from sqlalchemy.orm import Session
+
+from lunchbox.db import get_db
+from lunchbox.models import MenuItem, Subscription
+
+router = APIRouter(tags=["feeds"])
+
+
+def _build_calendar(subscription: Subscription, items: list[MenuItem]) -> Calendar:
+    cal = Calendar()
+    cal.add("prodid", "-//Lunchbox//Menu Feed//EN")
+    cal.add("version", "2.0")
+    cal.add("x-wr-calname", subscription.display_name)
+    cal.add("method", "PUBLISH")
+
+    # Group items by (date, meal_type)
+    grouped: dict[tuple, list[MenuItem]] = {}
+    for item in items:
+        key = (item.menu_date, item.meal_type)
+        grouped.setdefault(key, []).append(item)
+
+    # Sort by date, then meal_type alphabetically (Breakfast < Lunch)
+    for (menu_date, meal_type), day_items in sorted(grouped.items()):
+        # Apply category filter
+        if subscription.included_categories:
+            day_items = [
+                i for i in day_items if i.category in subscription.included_categories
+            ]
+
+        # Apply item exclusion filter
+        if subscription.excluded_items:
+            excluded_lower = {e.lower() for e in subscription.excluded_items}
+            day_items = [
+                i for i in day_items if i.item_name.lower() not in excluded_lower
+            ]
+
+        if not day_items:
+            continue
+
+        # Build summary: "Lunch: Pizza, Burger, Apple"
+        item_names = [i.item_name for i in day_items]
+        summary = f"{meal_type}: {', '.join(item_names)}"
+        if len(summary) > 100:
+            summary = summary[:97] + "..."
+
+        # Build description with categories
+        categories: dict[str, list[str]] = {}
+        for item in day_items:
+            categories.setdefault(item.category, []).append(item.item_name)
+
+        description_parts = []
+        for cat, names in categories.items():
+            description_parts.append(f"**{cat}:**")
+            for name in names:
+                description_parts.append(f"- {name}")
+            description_parts.append("")
+
+        event = Event()
+        event.add("summary", summary)
+        event.add("description", "\n".join(description_parts))
+        event.add("dtstart", menu_date)
+        # All-day events: DTEND is exclusive, so next day
+        event.add("dtend", menu_date + timedelta(days=1))
+        event.add(
+            "uid",
+            f"{subscription.feed_token}-{menu_date.isoformat()}-{meal_type}@lunchbox",
+        )
+        event.add("dtstamp", datetime.now(timezone.utc))
+        event.add("transp", "OPAQUE" if subscription.show_as_busy else "TRANSPARENT")
+
+        if subscription.alert_minutes:
+            alarm = Alarm()
+            alarm.add("action", "DISPLAY")
+            alarm.add("description", summary)
+            alarm.add("trigger", timedelta(minutes=-subscription.alert_minutes))
+            event.add_component(alarm)
+
+        cal.add_component(event)
+
+    return cal
+
+
+@router.get("/cal/{feed_token}.ics")
+def get_feed(feed_token: str, db: Session = Depends(get_db)):
+    try:
+        token_uuid = uuid.UUID(feed_token)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Feed not found")
+
+    subscription = (
+        db.query(Subscription)
+        .filter(
+            Subscription.feed_token == token_uuid,
+            Subscription.is_active.is_(True),
+        )
+        .first()
+    )
+    if not subscription:
+        raise HTTPException(status_code=404, detail="Feed not found")
+
+    items = (
+        db.query(MenuItem)
+        .filter(MenuItem.subscription_id == subscription.id)
+        .order_by(MenuItem.menu_date, MenuItem.meal_type)
+        .all()
+    )
+
+    cal = _build_calendar(subscription, items)
+    content = cal.to_ical()
+
+    # ETag for caching (not security, so MD5 is fine)
+    etag = hashlib.md5(content).hexdigest()  # noqa: S324
+    last_modified = max(
+        (i.fetched_at for i in items), default=datetime.now(timezone.utc)
+    )
+
+    return Response(
+        content=content,
+        media_type="text/calendar; charset=utf-8",
+        headers={
+            "ETag": f'"{etag}"',
+            "Last-Modified": last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT"),
+            "Cache-Control": "max-age=3600",
+        },
+    )

--- a/src/lunchbox/main.py
+++ b/src/lunchbox/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from starlette.middleware.sessions import SessionMiddleware
 
+from lunchbox.api.feeds import router as feeds_router
 from lunchbox.auth.router import router as auth_router
 from lunchbox.config import settings
 
@@ -19,6 +20,7 @@ app.add_middleware(
     SessionMiddleware, secret_key=settings.secret_key, max_age=30 * 24 * 3600
 )
 app.include_router(auth_router)
+app.include_router(feeds_router)
 
 
 @app.get("/health")

--- a/tests/integration/test_feeds_api.py
+++ b/tests/integration/test_feeds_api.py
@@ -1,0 +1,53 @@
+import uuid
+from datetime import date
+
+from lunchbox.models import MenuItem, Subscription, User
+
+
+def test_feed_returns_ical(client, db):
+    user = User(google_id="feed-test", email="t@t.com", name="T")
+    db.add(user)
+    db.flush()
+
+    feed_token = uuid.uuid4()
+    sub = Subscription(
+        user_id=user.id,
+        school_id="abc",
+        school_name="Test School",
+        grade="05",
+        meal_configs=[],
+        display_name="Test School",
+        feed_token=feed_token,
+    )
+    db.add(sub)
+    db.flush()
+
+    item = MenuItem(
+        subscription_id=sub.id,
+        school_id="abc",
+        menu_date=date(2026, 3, 16),
+        meal_type="Lunch",
+        serving_line="Traditional",
+        grade="05",
+        category="Entrees",
+        item_name="Pizza",
+    )
+    db.add(item)
+    db.commit()
+
+    response = client.get(f"/cal/{feed_token}.ics")
+    assert response.status_code == 200
+    assert "text/calendar" in response.headers["content-type"]
+    assert "VCALENDAR" in response.text
+    assert "Pizza" in response.text
+
+
+def test_feed_not_found(client):
+    fake_token = uuid.uuid4()
+    response = client.get(f"/cal/{fake_token}.ics")
+    assert response.status_code == 404
+
+
+def test_feed_invalid_token(client):
+    response = client.get("/cal/not-a-uuid.ics")
+    assert response.status_code == 404

--- a/tests/unit/test_feeds.py
+++ b/tests/unit/test_feeds.py
@@ -1,0 +1,107 @@
+import uuid
+from datetime import date, datetime, timezone
+
+from lunchbox.api.feeds import _build_calendar
+from lunchbox.models import MenuItem, Subscription
+
+
+def _make_subscription(**overrides):
+    defaults = dict(
+        id=uuid.uuid4(),
+        feed_token=uuid.uuid4(),
+        display_name="Test School",
+        included_categories=None,
+        excluded_items=None,
+        alert_minutes=None,
+        show_as_busy=False,
+    )
+    defaults.update(overrides)
+    sub = Subscription.__new__(Subscription)
+    for k, v in defaults.items():
+        setattr(sub, k, v)
+    return sub
+
+
+def _make_item(sub_id, menu_date, meal_type, category, item_name):
+    item = MenuItem.__new__(MenuItem)
+    item.subscription_id = sub_id
+    item.menu_date = menu_date
+    item.meal_type = meal_type
+    item.category = category
+    item.item_name = item_name
+    item.fetched_at = datetime.now(timezone.utc)
+    return item
+
+
+class TestBuildCalendar:
+    def test_basic_feed(self):
+        sub = _make_subscription()
+        items = [
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Entrees", "Pizza"),
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Fruits", "Apple"),
+        ]
+        cal = _build_calendar(sub, items)
+        ical = cal.to_ical().decode()
+
+        assert "VCALENDAR" in ical
+        assert "VEVENT" in ical
+        assert "Pizza" in ical
+        assert "Apple" in ical
+        assert "TRANSPARENT" in ical
+
+    def test_category_filter(self):
+        sub = _make_subscription(included_categories=["Entrees"])
+        items = [
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Entrees", "Pizza"),
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Milk", "1% Milk"),
+        ]
+        cal = _build_calendar(sub, items)
+        ical = cal.to_ical().decode()
+
+        assert "Pizza" in ical
+        assert "Milk" not in ical
+
+    def test_excluded_items(self):
+        sub = _make_subscription(excluded_items=["PB&J Sandwich"])
+        items = [
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Entrees", "Pizza"),
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Entrees", "PB&J Sandwich"),
+        ]
+        cal = _build_calendar(sub, items)
+        ical = cal.to_ical().decode()
+
+        assert "Pizza" in ical
+        assert "PB&J" not in ical
+
+    def test_multiple_meals_sorted(self):
+        sub = _make_subscription()
+        items = [
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Entrees", "Pizza"),
+            _make_item(sub.id, date(2026, 3, 16), "Breakfast", "Entrees", "Eggs"),
+        ]
+        cal = _build_calendar(sub, items)
+        ical = cal.to_ical().decode()
+
+        assert "Lunch: Pizza" in ical
+        assert "Breakfast: Eggs" in ical
+
+    def test_busy_flag(self):
+        sub = _make_subscription(show_as_busy=True)
+        items = [
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Entrees", "Pizza"),
+        ]
+        cal = _build_calendar(sub, items)
+        ical = cal.to_ical().decode()
+        assert "OPAQUE" in ical
+
+    def test_excluded_items_case_insensitive(self):
+        sub = _make_subscription(excluded_items=["pb&j sandwich"])
+        items = [
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Entrees", "PB&J Sandwich"),
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Entrees", "Pizza"),
+        ]
+        cal = _build_calendar(sub, items)
+        ical = cal.to_ical().decode()
+
+        assert "PB&J" not in ical
+        assert "Pizza" in ical

--- a/tests/unit/test_feeds.py
+++ b/tests/unit/test_feeds.py
@@ -105,3 +105,13 @@ class TestBuildCalendar:
 
         assert "PB&J" not in ical
         assert "Pizza" in ical
+
+    def test_alarm_when_alert_minutes_set(self):
+        sub = _make_subscription(alert_minutes=15)
+        items = [
+            _make_item(sub.id, date(2026, 3, 16), "Lunch", "Entrees", "Pizza"),
+        ]
+        cal = _build_calendar(sub, items)
+        ical = cal.to_ical().decode()
+        assert "VALARM" in ical
+        assert "TRIGGER" in ical


### PR DESCRIPTION
## Summary
Closes #8

- `GET /cal/{token}.ics` generates VCALENDAR from stored menu data
- Category filters and item exclusions applied at generation time
- VALARM support (configurable alert minutes)
- TRANSP for busy/free display
- ETag + Last-Modified + Cache-Control headers
- DTEND set to next day for correct all-day event duration
- Case-insensitive item exclusion matching

## Test plan
- [ ] Valid .ics output with correct VEVENT structure
- [ ] Category filters and item exclusions work
- [ ] 404 for invalid/missing feed tokens
- [ ] `ruff check` passes