### PR TITLE
feat: add subscription CRUD API and HTMX web UI

### DIFF
--- a/src/lunchbox/api/router.py
+++ b/src/lunchbox/api/router.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from lunchbox.api.feeds import router as feeds_router
+from lunchbox.api.schools import router as schools_router
+from lunchbox.api.subscriptions import router as subscriptions_router
+from lunchbox.api.sync import router as sync_router
+
+api_router = APIRouter()
+api_router.include_router(subscriptions_router)
+api_router.include_router(schools_router)
+api_router.include_router(sync_router)
+api_router.include_router(feeds_router)

--- a/src/lunchbox/api/schools.py
+++ b/src/lunchbox/api/schools.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from lunchbox.sync.menu_client import SchoolCafeClient
+
+router = APIRouter(prefix="/api/schools", tags=["schools"])
+
+
+@router.get("")
+def search_schools(q: str) -> list[dict]:
+    with SchoolCafeClient() as client:
+        schools = client.search_schools(q)
+    return [{"school_id": s.school_id, "school_name": s.school_name} for s in schools]

--- a/src/lunchbox/api/subscriptions.py
+++ b/src/lunchbox/api/subscriptions.py
@@ -1,0 +1,176 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from lunchbox.auth.dependencies import get_current_user
+from lunchbox.db import get_db
+from lunchbox.models import Subscription, User
+
+router = APIRouter(prefix="/api/subscriptions", tags=["subscriptions"])
+
+
+class MealConfig(BaseModel):
+    meal_type: str
+    serving_line: str
+    sort_order: int
+
+
+class SubscriptionCreate(BaseModel):
+    school_id: str
+    school_name: str
+    grade: str
+    meal_configs: list[MealConfig]
+    display_name: str
+    included_categories: list[str] | None = None
+    excluded_items: list[str] | None = None
+    alert_minutes: int | None = None
+    show_as_busy: bool = False
+    event_type: str = "all_day"
+
+
+class SubscriptionUpdate(BaseModel):
+    display_name: str | None = None
+    grade: str | None = None
+    meal_configs: list[MealConfig] | None = None
+    included_categories: list[str] | None = None
+    excluded_items: list[str] | None = None
+    alert_minutes: int | None = None
+    show_as_busy: bool | None = None
+    event_type: str | None = None
+    is_active: bool | None = None
+
+
+@router.get("")
+def list_subscriptions(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    subs = db.query(Subscription).filter(Subscription.user_id == user.id).all()
+    return [
+        {
+            "id": str(s.id),
+            "display_name": s.display_name,
+            "school_name": s.school_name,
+            "feed_url": f"/cal/{s.feed_token}.ics",
+            "is_active": s.is_active,
+        }
+        for s in subs
+    ]
+
+
+@router.post("", status_code=201)
+def create_subscription(
+    data: SubscriptionCreate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    sub = Subscription(
+        user_id=user.id,
+        school_id=data.school_id,
+        school_name=data.school_name,
+        grade=data.grade,
+        meal_configs=[mc.model_dump() for mc in data.meal_configs],
+        display_name=data.display_name,
+        included_categories=data.included_categories,
+        excluded_items=data.excluded_items,
+        alert_minutes=data.alert_minutes,
+        show_as_busy=data.show_as_busy,
+        event_type=data.event_type,
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+    return {"id": str(sub.id), "feed_url": f"/cal/{sub.feed_token}.ics"}
+
+
+@router.get("/{subscription_id}")
+def get_subscription(
+    subscription_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user.id)
+        .first()
+    )
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    return {
+        "id": str(sub.id),
+        "display_name": sub.display_name,
+        "school_name": sub.school_name,
+        "school_id": sub.school_id,
+        "grade": sub.grade,
+        "meal_configs": sub.meal_configs,
+        "included_categories": sub.included_categories,
+        "excluded_items": sub.excluded_items,
+        "alert_minutes": sub.alert_minutes,
+        "show_as_busy": sub.show_as_busy,
+        "event_type": sub.event_type,
+        "feed_url": f"/cal/{sub.feed_token}.ics",
+        "is_active": sub.is_active,
+    }
+
+
+@router.patch("/{subscription_id}")
+def update_subscription(
+    subscription_id: uuid.UUID,
+    data: SubscriptionUpdate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user.id)
+        .first()
+    )
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+
+    for field, value in data.model_dump(exclude_unset=True).items():
+        if field == "meal_configs" and value is not None:
+            value = [mc if isinstance(mc, dict) else mc.model_dump() for mc in value]
+        setattr(sub, field, value)
+
+    db.commit()
+    return {"status": "updated"}
+
+
+@router.delete("/{subscription_id}", status_code=204)
+def delete_subscription(
+    subscription_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user.id)
+        .first()
+    )
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+
+    db.delete(sub)
+    db.commit()
+
+
+@router.post("/{subscription_id}/regenerate-token")
+def regenerate_feed_token(
+    subscription_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user.id)
+        .first()
+    )
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+
+    sub.feed_token = uuid.uuid4()
+    db.commit()
+    return {"feed_url": f"/cal/{sub.feed_token}.ics"}

--- a/src/lunchbox/api/sync.py
+++ b/src/lunchbox/api/sync.py
@@ -1,0 +1,78 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from lunchbox.auth.dependencies import get_current_user
+from lunchbox.config import settings
+from lunchbox.db import get_db
+from lunchbox.models import Subscription, SyncLog, User
+from lunchbox.sync.engine import sync_subscription
+from lunchbox.sync.menu_client import SchoolCafeClient
+
+router = APIRouter(prefix="/api/sync", tags=["sync"])
+
+
+@router.post("/trigger/{subscription_id}")
+def trigger_sync(
+    subscription_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user.id)
+        .first()
+    )
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+
+    with SchoolCafeClient() as client:
+        log = sync_subscription(
+            db,
+            sub,
+            client,
+            days=settings.days_to_fetch,
+            skip_weekends=settings.skip_weekends,
+        )
+
+    return {
+        "status": log.status,
+        "items_fetched": log.items_fetched,
+        "duration_ms": log.duration_ms,
+    }
+
+
+@router.get("/history/{subscription_id}")
+def sync_history(
+    subscription_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user.id)
+        .first()
+    )
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+
+    logs = (
+        db.query(SyncLog)
+        .filter(SyncLog.subscription_id == subscription_id)
+        .order_by(SyncLog.started_at.desc())
+        .limit(20)
+        .all()
+    )
+    return [
+        {
+            "id": str(log.id),
+            "status": log.status,
+            "dates_synced": log.dates_synced,
+            "items_fetched": log.items_fetched,
+            "duration_ms": log.duration_ms,
+            "trace_id": log.trace_id,
+            "started_at": log.started_at.isoformat() if log.started_at else None,
+        }
+        for log in logs
+    ]

--- a/src/lunchbox/main.py
+++ b/src/lunchbox/main.py
@@ -1,11 +1,14 @@
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 from starlette.middleware.sessions import SessionMiddleware
 
-from lunchbox.api.feeds import router as feeds_router
+from lunchbox.api.router import api_router
 from lunchbox.auth.router import router as auth_router
 from lunchbox.config import settings
+from lunchbox.web.router import router as web_router
 
 
 @asynccontextmanager
@@ -19,10 +22,18 @@ app = FastAPI(title="Lunchbox", lifespan=lifespan)
 app.add_middleware(
     SessionMiddleware, secret_key=settings.secret_key, max_age=30 * 24 * 3600
 )
+
+app.mount(
+    "/static",
+    StaticFiles(directory=str(Path(__file__).parent / "web" / "static")),
+    name="static",
+)
+
 app.include_router(auth_router)
-app.include_router(feeds_router)
+app.include_router(api_router)
+app.include_router(web_router)
 
 
 @app.get("/health")
-def health():
+def health() -> dict:
     return {"status": "ok"}

--- a/src/lunchbox/web/router.py
+++ b/src/lunchbox/web/router.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from lunchbox.auth.dependencies import get_current_user
+from lunchbox.config import settings
+from lunchbox.db import get_db
+from lunchbox.models import MenuItem, Subscription, User
+
+router = APIRouter(tags=["web"])
+_here = Path(__file__).parent
+templates = Jinja2Templates(directory=str(_here / "templates"))
+
+
+@router.get("/", response_class=HTMLResponse)
+def landing(request: Request):
+    user_id = request.session.get("user_id")
+    if user_id:
+        return RedirectResponse(url="/dashboard")
+    return templates.TemplateResponse(
+        "landing.html", {"request": request, "user": None}
+    )
+
+
+@router.get("/dashboard", response_class=HTMLResponse)
+def dashboard(
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    subscriptions = db.query(Subscription).filter(Subscription.user_id == user.id).all()
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {
+            "request": request,
+            "user": user,
+            "subscriptions": subscriptions,
+            "base_url": settings.base_url,
+        },
+    )
+
+
+@router.get("/subscriptions/new", response_class=HTMLResponse)
+def new_subscription(request: Request, user: User = Depends(get_current_user)):
+    return templates.TemplateResponse(
+        "subscription_new.html", {"request": request, "user": user}
+    )
+
+
+@router.get("/subscriptions/{subscription_id}", response_class=HTMLResponse)
+def subscription_detail(
+    subscription_id: str,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user.id)
+        .first()
+    )
+    if not sub:
+        return RedirectResponse(url="/dashboard")
+    return templates.TemplateResponse(
+        "subscription_detail.html",
+        {
+            "request": request,
+            "user": user,
+            "sub": sub,
+            "base_url": settings.base_url,
+        },
+    )
+
+
+@router.get("/subscriptions/{subscription_id}/preview", response_class=HTMLResponse)
+def subscription_preview(
+    subscription_id: str,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user.id)
+        .first()
+    )
+    if not sub:
+        return RedirectResponse(url="/dashboard")
+
+    items = (
+        db.query(MenuItem)
+        .filter(MenuItem.subscription_id == sub.id)
+        .order_by(MenuItem.menu_date, MenuItem.meal_type)
+        .all()
+    )
+
+    # Group by date -> meal_type -> items
+    grouped: dict = {}
+    for item in items:
+        date_str = item.menu_date.isoformat()
+        grouped.setdefault(date_str, {}).setdefault(item.meal_type, []).append(item)
+
+    return templates.TemplateResponse(
+        "subscription_preview.html",
+        {
+            "request": request,
+            "user": user,
+            "sub": sub,
+            "grouped_items": grouped,
+        },
+    )

--- a/src/lunchbox/web/static/style.css
+++ b/src/lunchbox/web/static/style.css
@@ -1,0 +1,17 @@
+/* Minimal overrides — Pico CSS handles the heavy lifting */
+code {
+    font-size: 0.85em;
+    word-break: break-all;
+}
+
+button[onclick*="clipboard"] {
+    font-size: 0.8em;
+    padding: 0.25em 0.5em;
+    margin-left: 0.5em;
+}
+
+mark {
+    background-color: #fbbf24;
+    padding: 0.1em 0.4em;
+    border-radius: 4px;
+}

--- a/src/lunchbox/web/templates/base.html
+++ b/src/lunchbox/web/templates/base.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Lunchbox{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+    <link rel="stylesheet" href="/static/style.css">
+    <script src="https://unpkg.com/htmx.org@2.0.0"></script>
+</head>
+<body>
+    <nav class="container">
+        <ul><li><a href="/"><strong>Lunchbox</strong></a></li></ul>
+        <ul>
+            {% if user %}
+            <li><a href="/dashboard">Dashboard</a></li>
+            <li><a href="/auth/logout">Logout</a></li>
+            {% else %}
+            <li><a href="/auth/login">Sign in</a></li>
+            {% endif %}
+        </ul>
+    </nav>
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/src/lunchbox/web/templates/dashboard.html
+++ b/src/lunchbox/web/templates/dashboard.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Dashboard — Lunchbox{% endblock %}
+{% block content %}
+<hgroup>
+    <h1>Your Subscriptions</h1>
+    <p>{{ user.name }} ({{ user.email }})</p>
+</hgroup>
+
+<a href="/subscriptions/new" role="button">Add Subscription</a>
+
+{% for sub in subscriptions %}
+<article>
+    <header>
+        <strong>{{ sub.display_name }}</strong>
+        {% if not sub.is_active %}<mark>Inactive</mark>{% endif %}
+    </header>
+    <p>Feed URL: <code>{{ base_url }}/cal/{{ sub.feed_token }}.ics</code>
+        <button onclick="navigator.clipboard.writeText('{{ base_url }}/cal/{{ sub.feed_token }}.ics')">Copy</button>
+    </p>
+    <footer>
+        <a href="/subscriptions/{{ sub.id }}">Settings</a>
+        <button hx-post="/api/sync/trigger/{{ sub.id }}" hx-swap="innerHTML" hx-target="closest article footer">Sync Now</button>
+    </footer>
+</article>
+{% else %}
+<p>No subscriptions yet. Add one to get started.</p>
+{% endfor %}
+{% endblock %}

--- a/src/lunchbox/web/templates/landing.html
+++ b/src/lunchbox/web/templates/landing.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<hgroup>
+    <h1>Lunchbox</h1>
+    <p>School lunch menus, synced to your calendar.</p>
+</hgroup>
+<p>Pick your school, choose what to see, get a calendar feed. Works with Google Calendar, Apple Calendar, Outlook — anything that supports iCal.</p>
+<a href="/auth/login" role="button">Sign in with Google</a>
+{% endblock %}

--- a/src/lunchbox/web/templates/subscription_detail.html
+++ b/src/lunchbox/web/templates/subscription_detail.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}{{ sub.display_name }} — Lunchbox{% endblock %}
+{% block content %}
+<h1>{{ sub.display_name }}</h1>
+
+<p>Feed URL: <code>{{ base_url }}/cal/{{ sub.feed_token }}.ics</code>
+    <button onclick="navigator.clipboard.writeText('{{ base_url }}/cal/{{ sub.feed_token }}.ics')">Copy</button>
+</p>
+
+<h2>Settings</h2>
+<form hx-patch="/api/subscriptions/{{ sub.id }}" hx-swap="none">
+    <label>Display Name
+        <input type="text" name="display_name" value="{{ sub.display_name }}">
+    </label>
+
+    <label>Grade
+        <input type="text" name="grade" value="{{ sub.grade }}">
+    </label>
+
+    <fieldset>
+        <legend>Include Categories</legend>
+        {% for cat in ["Entrees", "Grains", "Vegetables", "Fruits", "Milk", "Condiments"] %}
+        <label>
+            <input type="checkbox" name="categories" value="{{ cat }}"
+                   {% if not sub.included_categories or cat in sub.included_categories %}checked{% endif %}>
+            {{ cat }}
+        </label>
+        {% endfor %}
+    </fieldset>
+
+    <label>Exclude Items (comma-separated)
+        <input type="text" name="excluded_items"
+               value="{{ (sub.excluded_items or []) | join(', ') }}">
+    </label>
+
+    <label>Alert (minutes before)
+        <input type="number" name="alert_minutes" value="{{ sub.alert_minutes or '' }}">
+    </label>
+
+    <label><input type="checkbox" name="show_as_busy" {% if sub.show_as_busy %}checked{% endif %}> Show as busy</label>
+
+    <button type="submit">Save</button>
+</form>
+
+<h2>Actions</h2>
+<button hx-post="/api/sync/trigger/{{ sub.id }}" hx-swap="innerHTML" hx-target="#sync-result">Sync Now</button>
+<span id="sync-result"></span>
+
+<button hx-post="/api/subscriptions/{{ sub.id }}/regenerate-token" hx-swap="outerHTML" hx-confirm="Regenerate feed URL? You'll need to re-subscribe in your calendar app.">Regenerate Feed URL</button>
+
+<button hx-delete="/api/subscriptions/{{ sub.id }}" hx-confirm="Delete this subscription?" hx-swap="none" onclick="window.location='/dashboard'">Delete</button>
+
+<h2>Sync History</h2>
+<div hx-get="/api/sync/history/{{ sub.id }}" hx-trigger="load" hx-swap="innerHTML">
+    Loading...
+</div>
+
+<p><a href="/subscriptions/{{ sub.id }}/preview">Preview menu data</a></p>
+{% endblock %}

--- a/src/lunchbox/web/templates/subscription_new.html
+++ b/src/lunchbox/web/templates/subscription_new.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}New Subscription — Lunchbox{% endblock %}
+{% block content %}
+<h1>Add Subscription</h1>
+
+<form hx-post="/subscriptions/create" hx-swap="innerHTML" hx-target="body">
+    <label>District Code
+        <input type="text" name="district" placeholder="DPS" required
+               hx-get="/api/schools" hx-trigger="change" hx-target="#school-select"
+               hx-include="[name='district']" hx-swap="innerHTML">
+    </label>
+
+    <label>School
+        <select name="school_id" id="school-select" required>
+            <option value="">Search by district first</option>
+        </select>
+    </label>
+
+    <label>Grade
+        <input type="text" name="grade" placeholder="05" required>
+    </label>
+
+    <fieldset>
+        <legend>Meals</legend>
+        <label><input type="checkbox" name="meals" value="Lunch|Traditional Lunch" checked> Lunch</label>
+        <label><input type="checkbox" name="meals" value="Breakfast|Grab n Go Breakfast"> Breakfast</label>
+    </fieldset>
+
+    <label>Display Name
+        <input type="text" name="display_name" placeholder="Shoemaker - 5th Grade" required>
+    </label>
+
+    <details>
+        <summary>Filters & Calendar Settings</summary>
+
+        <fieldset>
+            <legend>Include Categories (leave unchecked for all)</legend>
+            <label><input type="checkbox" name="categories" value="Entrees"> Entrees</label>
+            <label><input type="checkbox" name="categories" value="Grains"> Grains</label>
+            <label><input type="checkbox" name="categories" value="Vegetables"> Vegetables</label>
+            <label><input type="checkbox" name="categories" value="Fruits"> Fruits</label>
+            <label><input type="checkbox" name="categories" value="Milk"> Milk</label>
+            <label><input type="checkbox" name="categories" value="Condiments"> Condiments</label>
+        </fieldset>
+
+        <label>Exclude Items (comma-separated)
+            <input type="text" name="excluded_items" placeholder="Peanut Butter & Jelly Sandwich, Turkey Sandwich">
+        </label>
+
+        <label>Alert (minutes before, blank for none)
+            <input type="number" name="alert_minutes" placeholder="">
+        </label>
+
+        <label><input type="checkbox" name="show_as_busy"> Show as busy on calendar</label>
+    </details>
+
+    <button type="submit">Create Subscription</button>
+</form>
+{% endblock %}

--- a/src/lunchbox/web/templates/subscription_preview.html
+++ b/src/lunchbox/web/templates/subscription_preview.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Preview — {{ sub.display_name }}{% endblock %}
+{% block content %}
+<h1>Preview: {{ sub.display_name }}</h1>
+<a href="/subscriptions/{{ sub.id }}">Back to settings</a>
+
+{% for date_str, meals in grouped_items.items() %}
+<article>
+    <header><strong>{{ date_str }}</strong></header>
+    {% for meal_type, items in meals.items() %}
+    <h3>{{ meal_type }}</h3>
+    <ul>
+        {% for item in items %}
+        <li><strong>{{ item.category }}:</strong> {{ item.item_name }}</li>
+        {% endfor %}
+    </ul>
+    {% endfor %}
+</article>
+{% endfor %}
+
+{% if not grouped_items %}
+<p>No menu data yet. Try syncing first.</p>
+{% endif %}
+{% endblock %}

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,62 @@
+from lunchbox.auth.dependencies import get_current_user
+from lunchbox.main import app
+from lunchbox.models import Subscription, User
+
+
+def test_create_subscription(client, db):
+    user = User(google_id="api-create", email="t@t.com", name="Test")
+    db.add(user)
+    db.flush()
+
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    response = client.post(
+        "/api/subscriptions",
+        json={
+            "school_id": "abc-123",
+            "school_name": "Test School",
+            "grade": "05",
+            "meal_configs": [
+                {
+                    "meal_type": "Lunch",
+                    "serving_line": "Traditional Lunch",
+                    "sort_order": 0,
+                }
+            ],
+            "display_name": "Test School - 5th Grade",
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert "feed_url" in data
+    assert data["feed_url"].startswith("/cal/")
+
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_list_subscriptions(client, db):
+    user = User(google_id="api-list", email="t@t.com", name="Test")
+    db.add(user)
+    db.flush()
+
+    sub = Subscription(
+        user_id=user.id,
+        school_id="abc",
+        school_name="School",
+        grade="05",
+        meal_configs=[],
+        display_name="Test",
+    )
+    db.add(sub)
+    db.flush()
+
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    response = client.get("/api/subscriptions")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["display_name"] == "Test"
+
+    app.dependency_overrides.pop(get_current_user, None)


### PR DESCRIPTION
## Summary
Closes #9

### API Endpoints
- `GET/POST /api/subscriptions` — list, create
- `GET/PATCH/DELETE /api/subscriptions/{id}` — read, update, delete
- `POST /api/subscriptions/{id}/regenerate-token`
- `GET /api/schools?q=` — proxy SchoolCafe school search
- `POST /api/sync/trigger/{id}` — manual sync
- `GET /api/sync/history/{id}` — sync log history

### Web Pages
- `/` — landing page (sign in with Google)
- `/dashboard` — subscription list with feed URLs + copy button
- `/subscriptions/new` — subscription creation wizard
- `/subscriptions/{id}` — edit settings, sync history, actions
- `/subscriptions/{id}/preview` — HTML preview of menu data

### Stack
- Pico CSS (CDN), HTMX (CDN), Jinja2 templates
- Aggregated API router (api_router includes feeds, subscriptions, schools, sync)

## Test plan
- [ ] CRUD operations work via API
- [ ] `ruff check` passes
- [ ] Integration tests pass