### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,47 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: lunchbox_test
+          POSTGRES_USER: lunchbox
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Lint
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Test
+        env:
+          SECRET_KEY: test-ci-secret
+          TEST_DATABASE_URL: postgresql://lunchbox:test@localhost:5432/lunchbox_test
+        run: pytest -v
+
+      # pr-toolkit review is required before merge — run via Claude Code on each PR.


### PR DESCRIPTION
## Summary
Closes #11

- Trigger: pull_request to main
- Postgres 16 service container for tests
- Steps: ruff check + format, pytest
- SECRET_KEY and TEST_DATABASE_URL set for CI
- pr-toolkit review run manually via Claude Code on each PR

## Test plan
- [ ] Workflow file is valid YAML
- [ ] CI would run on PRs to main