### PR TITLE
chore: add Claude Code automations

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,50 @@
+---
+name: security-reviewer
+description: Review auth, API endpoints, and external integrations for security vulnerabilities
+when_to_use: Use when reviewing PRs that touch authentication, API routes, database queries, or external API integrations
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+---
+
+# Security Reviewer
+
+Review the Lunchbox codebase for security vulnerabilities, focusing on areas with the highest risk surface.
+
+## Review Checklist
+
+### Authentication & Sessions
+- Google OAuth flow in `src/lunchbox/auth/` — verify state parameter, token validation, redirect URI handling
+- Session management — check for secure cookie flags, session fixation, expiry
+- CRON_SECRET auth on `/api/sync/cron` — verify constant-time comparison, no timing leaks
+
+### API Endpoints
+- All routes in `src/lunchbox/api/` — check for:
+  - Missing authentication on protected endpoints
+  - SQL injection via SQLAlchemy (parameterized queries only)
+  - IDOR (insecure direct object references) on subscription/user endpoints
+  - Input validation on user-supplied data
+
+### External API Calls
+- SchoolCafe client in `src/lunchbox/sync/menu_client.py` — check for:
+  - SSRF risks if URLs are user-controllable
+  - Response parsing safety (no eval, no unsafe deserialization)
+  - Timeout configuration on httpx calls
+
+### Template Rendering
+- Jinja2 templates in `src/lunchbox/web/` — check for:
+  - XSS via unescaped output (autoescaping should be on)
+  - Template injection
+
+### Database
+- SQLAlchemy queries — verify no raw SQL with string interpolation
+- Alembic migrations — check for privilege escalation or data exposure
+
+## Output Format
+
+Report findings as:
+- **CRITICAL**: Must fix before merge (auth bypass, injection, data exposure)
+- **WARNING**: Should fix soon (missing headers, weak validation)
+- **INFO**: Best practice suggestions

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,11 +3,22 @@
     "deny": [
       "Edit(file_path=**/client_secret.json)",
       "Edit(file_path=**/token.json)",
+      "Edit(file_path=**/.env*)",
       "Write(file_path=**/client_secret.json)",
       "Write(file_path=**/token.json)",
+      "Write(file_path=**/.env*)",
       "Bash(rm -rf:*)",
       "Bash(docker compose down -v:*)",
       "Bash(git push --force:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "cd D:/docker/n8n && ruff format \"$CLAUDE_FILE_PATH\" 2>/dev/null; ruff check --fix \"$CLAUDE_FILE_PATH\" 2>/dev/null; true",
+        "description": "Auto-format and fix Python files with Ruff after edits"
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,6 @@
       "Write(file_path=**/token.json)",
       "Write(file_path=**/.env*)",
       "Bash(rm -rf:*)",
-      "Bash(docker compose down -v:*)",
       "Bash(git push --force:*)"
     ]
   },
@@ -16,7 +15,7 @@
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": "cd D:/docker/n8n && ruff format \"$CLAUDE_FILE_PATH\" 2>/dev/null; ruff check --fix \"$CLAUDE_FILE_PATH\" 2>/dev/null; true",
+        "command": "[[ \"$CLAUDE_FILE_PATH\" == *.py ]] && { ruff format \"$CLAUDE_FILE_PATH\" 2>/dev/null; ruff check --fix \"$CLAUDE_FILE_PATH\" 2>/dev/null; }; true",
         "description": "Auto-format and fix Python files with Ruff after edits"
       }
     ]

--- a/.claude/skills/create-migration/SKILL.md
+++ b/.claude/skills/create-migration/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: create-migration
+description: Generate and apply an Alembic migration against Neon Postgres via Vercel env vars
+disable-model-invocation: true
+---
+
+# Create Migration
+
+Generate an Alembic migration for Neon Postgres. This workflow handles the Vercel env var dance required for Neon's unpooled connection.
+
+## Steps
+
+1. **Confirm the migration purpose** — ask what schema change is needed if not already clear.
+
+2. **Pull Vercel env vars**:
+   ```bash
+   vercel env pull .env.vercel
+   ```
+
+3. **Source the env and generate migration**:
+   ```bash
+   source .env.vercel
+   alembic revision --autogenerate -m "<description>"
+   ```
+
+4. **Review the generated migration** — read the new file in `alembic/versions/` and verify:
+   - Only expected changes are present (no spurious diffs)
+   - Downgrade path is correct
+   - No data-destructive operations without explicit user approval
+
+5. **Apply the migration**:
+   ```bash
+   source .env.vercel
+   alembic upgrade head
+   ```
+
+6. **Clean up secrets**:
+   ```bash
+   rm .env.vercel
+   ```
+   NEVER commit `.env.vercel`.
+
+7. **Report** — show the migration file path and summary of changes applied.
+
+## Gotchas
+
+- Always use the **unpooled** connection URL for migrations (Vercel's `DATABASE_URL` from env pull should be unpooled)
+- Use `printf` not `echo` when piping values to `vercel env add` (echo adds trailing newline)
+- NullPool is required in `db.py` for serverless — don't change pool settings in migrations

--- a/.claude/skills/sync-debug/SKILL.md
+++ b/.claude/skills/sync-debug/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: sync-debug
+description: Debug SchoolCafe menu sync failures — check logs, test menu client, diagnose issues
+disable-model-invocation: true
+---
+
+# Sync Debug
+
+Diagnose and fix SchoolCafe menu sync failures. The SchoolCafe API is external and fragile — schema drift and silent failures are common.
+
+## Steps
+
+1. **Check recent sync logs** — look at the `sync_log` table for recent entries:
+   - Query for failed syncs or syncs with 0 items
+   - Note any error messages or patterns
+
+2. **Check Vercel function logs**:
+   ```bash
+   vercel logs https://lunchbox-ebon.vercel.app/api/sync/cron --limit 20
+   ```
+
+3. **Test the menu client directly** — read `src/lunchbox/sync/menu_client.py` and `src/lunchbox/sync/providers.py`, then:
+   - Check if SchoolCafe endpoints are responding
+   - Verify the response shape matches what the parser expects
+   - Look for schema drift (new fields, changed structure, different date formats)
+
+4. **Test the sync engine** — read `src/lunchbox/sync/engine.py` and check:
+   - Are subscriptions active and pointing to valid schools?
+   - Is the upsert logic handling duplicates correctly?
+   - Are there transaction/connection issues (NullPool + Neon)?
+
+5. **Run unit tests** to confirm baseline:
+   ```bash
+   pytest tests/unit/test_menu_client.py tests/unit/test_sync_engine.py -v
+   ```
+
+6. **Diagnose and fix** — based on findings:
+   - If schema drift: update parser in `menu_client.py`, add defensive parsing
+   - If connection issues: check Neon status, verify DATABASE_URL
+   - If auth issues: verify CRON_SECRET matches Vercel config
+
+7. **Report** — summarize root cause and fix applied.
+
+## Key Files
+
+- `src/lunchbox/sync/menu_client.py` — SchoolCafe HTTP client and parser
+- `src/lunchbox/sync/engine.py` — sync orchestration and upsert logic
+- `src/lunchbox/sync/providers.py` — provider configuration
+- `src/lunchbox/api/sync.py` — cron endpoint (auth: `Authorization: Bearer <CRON_SECRET>`)
+- `src/lunchbox/models/` — ORM models including `sync_log`

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upwind-media/context7-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add **context7 MCP server** (`.mcp.json`) for live documentation lookup across FastAPI, SQLAlchemy, Alembic, etc.
- Add **create-migration** skill (`/create-migration`) — guided Alembic migration workflow against Neon Postgres
- Add **sync-debug** skill (`/sync-debug`) — diagnose SchoolCafe sync failures
- Add **Ruff auto-format hook** — PostToolUse hook runs `ruff format` + `ruff check --fix` on every edit
- Add **`.env` edit protection** — block accidental edits to `.env*` files via permissions deny
- Add **security-reviewer** subagent — reviews auth, API endpoints, and external integrations for vulnerabilities

## Test plan
- [ ] Verify `ruff format` hook fires on file edits (edit a `.py` file and confirm formatting)
- [ ] Verify `.env` edits are blocked (attempt to edit `.env` and confirm denial)
- [ ] Verify `/create-migration` and `/sync-debug` skills appear in skill list
- [ ] Verify context7 MCP server connects on session start

Closes #64