### PR TITLE
fix: harden SchoolCafe API client — retry, throttle, validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Check Alembic migrations
         env:
           DATABASE_URL: postgresql://lunchbox:test@localhost:5432/lunchbox_test
+          SECRET_KEY: test-ci-secret
         run: |
           if ls alembic/versions/*.py 1>/dev/null 2>&1; then
             alembic upgrade head

--- a/docs/superpowers/plans/2026-04-13-schoolcafe-client-hardening.md
+++ b/docs/superpowers/plans/2026-04-13-schoolcafe-client-hardening.md
@@ -1,0 +1,612 @@
+# SchoolCafe Client Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add retry with exponential backoff, rate limiting, and response validation to the SchoolCafe API client.
+
+**Architecture:** A centralized `_request()` method on `SchoolCafeClient` handles throttling, HTTP calls, and retry logic. Response validation is added at the caller level (`get_daily_menu()` and `search_schools()`). All changes are in `menu_client.py` + tests.
+
+**Tech Stack:** Python 3.11, httpx, respx (test mocking), pytest
+
+**Spec:** `docs/superpowers/specs/2026-04-13-schoolcafe-client-hardening-design.md`
+**Issues:** #59 (retry), #60 (rate limiting), #61 (response validation)
+
+---
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `src/lunchbox/sync/menu_client.py` | All implementation changes — `_request()`, `_throttle()`, constructor params, response validation |
+| `tests/unit/test_menu_client_http.py` | All new HTTP-level tests + updates to existing retry-affected tests |
+
+No new files created. No other files modified.
+
+---
+
+## Chunk 1: Retry + Throttle Infrastructure
+
+### Task 1: Update constructor and add throttle
+
+**Files:**
+- Modify: `src/lunchbox/sync/menu_client.py:81-89` (constructor)
+- Test: `tests/unit/test_menu_client_http.py`
+
+- [ ] **Step 1: Write failing test for constructor params**
+
+Add to `tests/unit/test_menu_client_http.py`:
+
+```python
+class TestClientConfig:
+    def test_default_constructor(self):
+        client = SchoolCafeClient()
+        assert client._max_retries == 3
+        assert client._retry_delays == (1, 2, 4)
+        assert client._min_request_delay == 0.1
+
+    def test_custom_constructor(self):
+        client = SchoolCafeClient(
+            timeout=10, max_retries=1, retry_delays=(0.5,), min_request_delay=0
+        )
+        assert client._max_retries == 1
+        assert client._retry_delays == (0.5,)
+        assert client._min_request_delay == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_menu_client_http.py::TestClientConfig -v`
+Expected: FAIL — `AttributeError: 'SchoolCafeClient' object has no attribute '_max_retries'`
+
+- [ ] **Step 3: Update constructor with new params**
+
+In `src/lunchbox/sync/menu_client.py`, replace the `__init__` method:
+
+```python
+def __init__(
+    self,
+    timeout: int = 30,
+    max_retries: int = 3,
+    retry_delays: tuple[float, ...] = (1, 2, 4),
+    min_request_delay: float = 0.1,
+):
+    self._client = httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}
+    )
+    self._max_retries = max_retries
+    self._retry_delays = retry_delays
+    self._min_request_delay = min_request_delay
+    self._last_request_time = 0.0
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_menu_client_http.py::TestClientConfig -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lunchbox/sync/menu_client.py tests/unit/test_menu_client_http.py
+git commit -m "feat: add constructor params for retry and throttle config (#59, #60)"
+```
+
+---
+
+### Task 2: Add `_throttle()` and `_request()` with retry logic
+
+**Files:**
+- Modify: `src/lunchbox/sync/menu_client.py` (add methods after constructor)
+- Test: `tests/unit/test_menu_client_http.py`
+
+- [ ] **Step 1: Write failing test — retry succeeds on second attempt**
+
+Add to `tests/unit/test_menu_client_http.py`:
+
+```python
+class TestRetry:
+    @respx.mock
+    def test_retry_succeeds_on_second_attempt(self, schoolcafe_fixture):
+        data = schoolcafe_fixture("normal_lunch")
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade")
+        route.side_effect = [
+            httpx.Response(500),
+            httpx.Response(200, json=data),
+        ]
+
+        with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert len(items) > 0
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_retry_exhausted_raises(self):
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade")
+        route.side_effect = [
+            httpx.Response(500),
+            httpx.Response(500),
+            httpx.Response(500),
+            httpx.Response(500),
+        ]
+
+        with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
+            with pytest.raises(httpx.HTTPStatusError):
+                client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert route.call_count == 4  # 1 initial + 3 retries
+
+    @respx.mock
+    def test_4xx_not_retried(self):
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade")
+        route.mock(return_value=httpx.Response(404))
+
+        with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
+            with pytest.raises(httpx.HTTPStatusError):
+                client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert route.call_count == 1  # no retries
+
+    @respx.mock
+    def test_timeout_retried(self, schoolcafe_fixture):
+        data = schoolcafe_fixture("normal_lunch")
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade")
+        route.side_effect = [
+            httpx.TimeoutException("timed out"),
+            httpx.Response(200, json=data),
+        ]
+
+        with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert len(items) > 0
+        assert route.call_count == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_menu_client_http.py::TestRetry -v`
+Expected: FAIL — retry tests fail because `get_daily_menu()` still calls `self._client.get()` directly
+
+- [ ] **Step 3: Implement `_throttle()` and `_request()`**
+
+First, add imports and constant at the **top of `menu_client.py`** (module level):
+
+```python
+import json
+import time
+```
+
+Add after the `CATEGORY_ALIASES` dict (module level):
+
+```python
+RETRY_AFTER_CAP = 10  # seconds — max we'll honor from Retry-After header
+```
+
+Then add these methods to the `SchoolCafeClient` class, after `__init__`:
+
+```python
+def _throttle(self):
+    elapsed = time.monotonic() - self._last_request_time
+    if self._min_request_delay > 0 and elapsed < self._min_request_delay:
+        time.sleep(self._min_request_delay - elapsed)
+
+def _request(self, url: str, **kwargs) -> httpx.Response:
+    last_exc = None
+
+    for attempt in range(self._max_retries + 1):
+        self._throttle()
+        self._last_request_time = time.monotonic()
+
+        try:
+            response = self._client.get(url, **kwargs)
+            response.raise_for_status()
+            return response
+        except httpx.TimeoutException as e:
+            last_exc = e
+            if attempt == self._max_retries:
+                raise
+            delay = self._retry_delays[min(attempt, len(self._retry_delays) - 1)]
+            logger.warning("Request timeout (attempt %d/%d), retrying in %.1fs", attempt + 1, self._max_retries, delay)
+            time.sleep(delay)
+        except httpx.HTTPStatusError as e:
+            last_exc = e
+            status = e.response.status_code
+            if status == 429:
+                retry_after = e.response.headers.get("Retry-After")
+                if retry_after:
+                    try:
+                        delay = min(float(retry_after), RETRY_AFTER_CAP)
+                    except ValueError:
+                        delay = self._retry_delays[min(attempt, len(self._retry_delays) - 1)]
+                else:
+                    delay = self._retry_delays[min(attempt, len(self._retry_delays) - 1)]
+            elif status >= 500:
+                delay = self._retry_delays[min(attempt, len(self._retry_delays) - 1)]
+            else:
+                raise  # 4xx (not 429) — don't retry
+
+            if attempt == self._max_retries:
+                raise
+            logger.warning("HTTP %d (attempt %d/%d), retrying in %.1fs", status, attempt + 1, self._max_retries, delay)
+            time.sleep(delay)
+
+    raise last_exc  # unreachable but satisfies type checker
+```
+
+- [ ] **Step 4: Wire `get_daily_menu()` to use `_request()`**
+
+Replace the HTTP call in `get_daily_menu()`:
+
+```python
+# Replace:
+#   response = self._client.get(
+#       f"{self.BASE_URL}/CalendarView/GetDailyMenuitemsByGrade",
+#       params=params,
+#   )
+#   response.raise_for_status()
+#   data = response.json()
+
+# With:
+response = self._request(
+    f"{self.BASE_URL}/CalendarView/GetDailyMenuitemsByGrade",
+    params=params,
+)
+data = response.json()
+```
+
+- [ ] **Step 5: Update existing tests that now retry**
+
+These tests must be updated BEFORE running the suite, since `get_daily_menu()` now retries.
+
+In `tests/unit/test_menu_client_http.py`, update `TestGetDailyMenu`:
+
+```python
+# test_http_500_raises — use max_retries=0
+@respx.mock
+def test_http_500_raises(self):
+    respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+        return_value=httpx.Response(500)
+    )
+
+    with SchoolCafeClient(max_retries=0) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+# test_timeout_raises — use max_retries=0
+@respx.mock
+def test_timeout_raises(self):
+    respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+        side_effect=httpx.TimeoutException("timed out")
+    )
+
+    with SchoolCafeClient(max_retries=0) as client:
+        with pytest.raises(httpx.TimeoutException):
+            client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+```
+
+- [ ] **Step 6: Wire `search_schools()` to use `_request()`**
+
+Replace both HTTP calls in `search_schools()`:
+
+```python
+# Replace both self._client.get() + raise_for_status() pairs with:
+response = self._request(
+    f"{self.BASE_URL}/GetISDByShortName",
+    params={"shortname": query},
+)
+districts = response.json()
+
+# ... existing district_id logic ...
+
+response = self._request(
+    f"{self.BASE_URL}/GetSchoolsList",
+    params={"districtId": district_id},
+)
+schools = response.json()
+```
+
+- [ ] **Step 7: Run retry tests and full suite**
+
+Run: `pytest tests/unit/test_menu_client_http.py tests/unit/test_menu_client.py -v`
+Expected: All tests PASS (retry tests pass, existing tests pass with max_retries=0)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lunchbox/sync/menu_client.py tests/unit/test_menu_client_http.py
+git commit -m "feat: add retry with exponential backoff and throttle to SchoolCafe client (#59, #60)"
+```
+
+---
+
+### Task 3: Add 429 tests
+
+**Files:**
+- Test: `tests/unit/test_menu_client_http.py`
+
+- [ ] **Step 1: Write 429 with Retry-After test**
+
+Add to `TestRetry` class:
+
+```python
+@respx.mock
+def test_429_respects_retry_after(self, schoolcafe_fixture):
+    data = schoolcafe_fixture("normal_lunch")
+    route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade")
+    route.side_effect = [
+        httpx.Response(429, headers={"Retry-After": "0"}),
+        httpx.Response(200, json=data),
+    ]
+
+    with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
+        items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+    assert len(items) > 0
+    assert route.call_count == 2
+
+@respx.mock
+def test_429_without_retry_after(self, schoolcafe_fixture):
+    data = schoolcafe_fixture("normal_lunch")
+    route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade")
+    route.side_effect = [
+        httpx.Response(429),  # no Retry-After header
+        httpx.Response(200, json=data),
+    ]
+
+    with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
+        items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+    assert len(items) > 0
+    assert route.call_count == 2
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_menu_client_http.py::TestRetry::test_429_respects_retry_after tests/unit/test_menu_client_http.py::TestRetry::test_429_without_retry_after -v`
+Expected: PASS (both)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_menu_client_http.py
+git commit -m "test: add 429 rate limit tests with and without Retry-After header (#60)"
+```
+
+---
+
+## Chunk 2: Response Validation
+
+### Task 4: Add response validation to `get_daily_menu()`
+
+**Files:**
+- Modify: `src/lunchbox/sync/menu_client.py:91-119` (`get_daily_menu` method)
+- Test: `tests/unit/test_menu_client_http.py`
+
+- [ ] **Step 1: Write failing tests for response validation**
+
+Add to `tests/unit/test_menu_client_http.py`:
+
+```python
+class TestResponseValidation:
+    @respx.mock
+    def test_malformed_json_returns_empty(self):
+        respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            return_value=httpx.Response(200, content=b"not json at all")
+        )
+
+        with SchoolCafeClient(max_retries=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert items == []
+
+    @respx.mock
+    def test_non_dict_response_returns_empty(self):
+        respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            return_value=httpx.Response(200, json=["not", "a", "dict"])
+        )
+
+        with SchoolCafeClient(max_retries=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert items == []
+
+    @respx.mock
+    def test_null_response_returns_empty(self):
+        respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            return_value=httpx.Response(200, json=None)
+        )
+
+        with SchoolCafeClient(max_retries=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert items == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_menu_client_http.py::TestResponseValidation -v`
+Expected: FAIL — `JSONDecodeError` or unexpected behavior (no guards in place)
+
+- [ ] **Step 3: Add validation to `get_daily_menu()`**
+
+In `get_daily_menu()`, replace the response parsing section after `_request()`:
+
+```python
+response = self._request(
+    f"{self.BASE_URL}/CalendarView/GetDailyMenuitemsByGrade",
+    params=params,
+)
+
+try:
+    data = response.json()
+except json.JSONDecodeError:
+    logger.warning("SchoolCafe returned invalid JSON for %s %s", school_id, menu_date)
+    return []
+
+if not isinstance(data, dict):
+    logger.warning("SchoolCafe returned non-dict response: %s", type(data).__name__)
+    return []
+
+drift_warnings = _detect_drift(data)
+for warning in drift_warnings:
+    logger.warning("SchoolCafe schema drift: %s", warning)
+
+return self._parse_response(data)
+```
+
+Add `import json` at the top of the file if not already present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_menu_client_http.py::TestResponseValidation -v`
+Expected: PASS (all 3)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lunchbox/sync/menu_client.py tests/unit/test_menu_client_http.py
+git commit -m "fix: validate SchoolCafe response before parsing (#61)"
+```
+
+---
+
+### Task 5: Add response validation to `search_schools()`
+
+**Files:**
+- Modify: `src/lunchbox/sync/menu_client.py:147-176` (`search_schools` method)
+- Test: `tests/unit/test_menu_client_http.py`
+
+- [ ] **Step 1: Write failing test for search validation**
+
+Add to `TestResponseValidation`:
+
+```python
+@respx.mock
+def test_search_malformed_json_returns_empty(self):
+    respx.get(f"{BASE_URL}/GetISDByShortName").mock(
+        return_value=httpx.Response(200, content=b"not json")
+    )
+
+    with SchoolCafeClient(max_retries=0) as client:
+        result = client.search_schools("test")
+
+    assert result == []
+
+@respx.mock
+def test_search_non_list_districts_returns_empty(self):
+    respx.get(f"{BASE_URL}/GetISDByShortName").mock(
+        return_value=httpx.Response(200, json={"error": "bad request"})
+    )
+
+    with SchoolCafeClient(max_retries=0) as client:
+        result = client.search_schools("test")
+
+    assert result == []
+
+@respx.mock
+def test_search_non_list_schools_returns_empty(self, schoolcafe_fixture):
+    districts = schoolcafe_fixture("search_districts")
+    respx.get(f"{BASE_URL}/GetISDByShortName").mock(
+        return_value=httpx.Response(200, json=districts)
+    )
+    respx.get(f"{BASE_URL}/GetSchoolsList").mock(
+        return_value=httpx.Response(200, json={"error": "bad"})
+    )
+
+    with SchoolCafeClient(max_retries=0) as client:
+        result = client.search_schools("springfield")
+
+    assert result == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_menu_client_http.py::TestResponseValidation::test_search_malformed_json_returns_empty tests/unit/test_menu_client_http.py::TestResponseValidation::test_search_non_list_districts_returns_empty tests/unit/test_menu_client_http.py::TestResponseValidation::test_search_non_list_schools_returns_empty -v`
+Expected: FAIL — `JSONDecodeError` or `TypeError`
+
+- [ ] **Step 3: Add validation to `search_schools()`**
+
+Replace `search_schools()`:
+
+```python
+def search_schools(self, query: str) -> list[SchoolInfo]:
+    response = self._request(
+        f"{self.BASE_URL}/GetISDByShortName",
+        params={"shortname": query},
+    )
+
+    try:
+        districts = response.json()
+    except json.JSONDecodeError:
+        logger.warning("SchoolCafe returned invalid JSON for school search: %s", query)
+        return []
+
+    if not isinstance(districts, list) or not districts:
+        return []
+
+    district_id = districts[0].get("ISDId")
+    if not district_id:
+        return []
+
+    response = self._request(
+        f"{self.BASE_URL}/GetSchoolsList",
+        params={"districtId": district_id},
+    )
+
+    try:
+        schools = response.json()
+    except json.JSONDecodeError:
+        logger.warning("SchoolCafe returned invalid JSON for schools list")
+        return []
+
+    if not isinstance(schools, list):
+        return []
+
+    return [
+        SchoolInfo(
+            school_id=s.get("SchoolId", ""),
+            school_name=s.get("SchoolName", ""),
+        )
+        for s in schools
+        if s.get("SchoolId")
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_menu_client_http.py::TestResponseValidation -v`
+Expected: PASS (all 6 validation tests)
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pytest tests/unit/test_menu_client_http.py tests/unit/test_menu_client.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lunchbox/sync/menu_client.py tests/unit/test_menu_client_http.py
+git commit -m "fix: add response validation to search_schools (#61)"
+```
+
+---
+
+### Task 6: Final verification and lint
+
+- [ ] **Step 1: Run ruff**
+
+Run: `ruff check src/lunchbox/sync/menu_client.py tests/unit/test_menu_client_http.py && ruff format --check src/lunchbox/sync/menu_client.py tests/unit/test_menu_client_http.py`
+Expected: Clean
+
+- [ ] **Step 2: Run full unit test suite**
+
+Run: `pytest tests/unit/ -v`
+Expected: All tests PASS, no regressions
+
+- [ ] **Step 3: Commit any lint fixes if needed**
+
+```bash
+git add -u && git commit -m "chore: lint fixes"
+```
+(Skip if nothing to fix.)

--- a/docs/superpowers/specs/2026-04-13-schoolcafe-client-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-13-schoolcafe-client-hardening-design.md
@@ -26,7 +26,7 @@ Both `get_daily_menu()` and `search_schools()` use `_request()` instead of calli
 
 **Retry logic:**
 - On HTTP 5xx or `httpx.TimeoutException`: wait `retry_delays[attempt]` seconds, retry
-- On HTTP 429: use `Retry-After` header if present (capped at 60s), otherwise use standard delay, retry
+- On HTTP 429: use `Retry-After` header if present (capped at 10s), otherwise use standard delay, retry
 - On HTTP 4xx (not 429): raise immediately, no retry
 - After `max_retries` exhausted: raise the last exception
 
@@ -40,7 +40,7 @@ After `_request()` returns successfully:
 2. Check `isinstance(data, dict)` — log warning if not, return `[]`
 3. Existing drift detection and `_parse_response()` proceed as before
 
-`search_schools()` already handles non-list responses gracefully (checks `if not districts`), so it only needs the `JSONDecodeError` guard.
+`search_schools()` needs both a `JSONDecodeError` guard and an `isinstance(districts, list)` check. The current `if not districts` only catches falsy values — a non-list response like `{"error": "..."}` would cause `districts[0]` to raise `TypeError`. Same `isinstance` guard needed for the schools list response.
 
 ### Constructor parameters
 
@@ -61,7 +61,7 @@ All new params have defaults matching the issue specs. Tests can pass `max_retri
 
 | File | Change |
 |------|--------|
-| `src/lunchbox/sync/menu_client.py` | Add `_request()`, `_throttle()`. Update `get_daily_menu()` and `search_schools()` to use `_request()`. Add JSON/dict validation in `get_daily_menu()`. Add `JSONDecodeError` guard in `search_schools()`. New constructor params. |
+| `src/lunchbox/sync/menu_client.py` | Add `_request()`, `_throttle()`. Update `get_daily_menu()` and `search_schools()` to use `_request()`. Add JSON/dict validation in `get_daily_menu()`. Add `JSONDecodeError` + `isinstance` guards in `search_schools()`. New constructor params. |
 | `tests/unit/test_menu_client_http.py` | Update `test_http_500_raises` and `test_timeout_raises` to use `max_retries=0`. Add new tests for retry, throttle, 429, and validation. |
 
 ### What stays the same
@@ -79,6 +79,7 @@ All new params have defaults matching the issue specs. Tests can pass `max_retri
 | `test_retry_exhausted_raises` | 3x 500 raises `HTTPStatusError` |
 | `test_4xx_not_retried` | 404 raises immediately (1 request, not 4) |
 | `test_429_respects_retry_after` | 429 with `Retry-After: 1` header retries after delay |
+| `test_429_without_retry_after` | 429 without header uses standard delay |
 | `test_timeout_retried` | Timeout then 200 returns data |
 | `test_malformed_json_returns_empty` | Non-JSON response body returns `[]` |
 | `test_non_dict_response_returns_empty` | JSON array response returns `[]` |
@@ -89,4 +90,12 @@ Existing tests `test_http_500_raises` and `test_timeout_raises` updated to pass 
 
 ### Error budget
 
-With 3 retries and delays of (1, 2, 4), worst case per request is 7 seconds. For 280 requests, if every request maxes out retries, total sync time = ~33 minutes. The Vercel function timeout is 60 seconds, but the engine already catches per-request failures — so individual timeouts don't kill the whole sync. The throttle adds 0.1s * 280 = 28 seconds baseline. Acceptable for a daily cron job.
+**Vercel constraint:** Each function invocation has a 60-second timeout. The cron endpoint calls `sync_all()` in a single invocation.
+
+**Happy path:** 280 requests × 0.1s throttle = 28s baseline + request time. Tight but feasible within 60s if SchoolCafe responds quickly (~50-100ms per call).
+
+**With retries:** Each retry adds 1-4s of sleep. A few retries are fine, but widespread failures (e.g., SchoolCafe down) will hit the 60s wall. This is acceptable because: (a) the engine catches per-request failures individually, so partial data is saved, and (b) if SchoolCafe is broadly failing, retrying won't help anyway.
+
+**`Retry-After` cap:** Set to 10s (not 60s) to avoid a single 429 consuming the entire budget.
+
+**Future consideration:** If subscription count grows beyond ~30, the throttle baseline alone exceeds 60s. At that point, the cron design needs chunking (multiple invocations). This is out of scope for this change.

--- a/docs/superpowers/specs/2026-04-13-schoolcafe-client-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-13-schoolcafe-client-hardening-design.md
@@ -1,0 +1,92 @@
+# SchoolCafe Client Hardening
+
+**Date:** 2026-04-13
+**Issues:** #59 (retry), #60 (rate limiting), #61 (response validation)
+**Scope:** `src/lunchbox/sync/menu_client.py` + tests
+
+## Problem
+
+The SchoolCafe API client has no resilience against transient failures. A single 503 or timeout loses a day's menu data. No throttling between requests risks hitting rate limits during bulk syncs (~280 calls per cron run). Malformed or unexpected responses crash the parser.
+
+## Design
+
+### Core: `_request()` method
+
+A private method on `SchoolCafeClient` that centralizes HTTP concerns: throttle, request, retry.
+
+```
+caller -> _request() -> throttle -> HTTP call -> return response
+                          ^                         |
+                          +-- retry (5xx/429/timeout) --+
+```
+
+Both `get_daily_menu()` and `search_schools()` use `_request()` instead of calling `self._client.get()` directly.
+
+**Throttle:** Sleep if less than `min_request_delay` seconds since the last request. Uses `time.monotonic()` for clock stability.
+
+**Retry logic:**
+- On HTTP 5xx or `httpx.TimeoutException`: wait `retry_delays[attempt]` seconds, retry
+- On HTTP 429: use `Retry-After` header if present (capped at 60s), otherwise use standard delay, retry
+- On HTTP 4xx (not 429): raise immediately, no retry
+- After `max_retries` exhausted: raise the last exception
+
+**Not retried:** `httpx.ConnectError`, `httpx.RequestError` subclasses other than timeout (network is down, DNS failure — retrying won't help within the sync window).
+
+### Response validation in `get_daily_menu()`
+
+After `_request()` returns successfully:
+
+1. Wrap `response.json()` in `try/except json.JSONDecodeError` — log warning, return `[]`
+2. Check `isinstance(data, dict)` — log warning if not, return `[]`
+3. Existing drift detection and `_parse_response()` proceed as before
+
+`search_schools()` already handles non-list responses gracefully (checks `if not districts`), so it only needs the `JSONDecodeError` guard.
+
+### Constructor parameters
+
+```python
+class SchoolCafeClient:
+    def __init__(
+        self,
+        timeout: int = 30,
+        max_retries: int = 3,
+        retry_delays: tuple[float, ...] = (1, 2, 4),
+        min_request_delay: float = 0.1,
+    ):
+```
+
+All new params have defaults matching the issue specs. Tests can pass `max_retries=0` to disable retries or `min_request_delay=0` to skip throttling.
+
+### What changes
+
+| File | Change |
+|------|--------|
+| `src/lunchbox/sync/menu_client.py` | Add `_request()`, `_throttle()`. Update `get_daily_menu()` and `search_schools()` to use `_request()`. Add JSON/dict validation in `get_daily_menu()`. Add `JSONDecodeError` guard in `search_schools()`. New constructor params. |
+| `tests/unit/test_menu_client_http.py` | Update `test_http_500_raises` and `test_timeout_raises` to use `max_retries=0`. Add new tests for retry, throttle, 429, and validation. |
+
+### What stays the same
+
+- `_parse_response()`, `_detect_drift()`, `_extract_item_name()`, `_normalize_category()` — untouched
+- `engine.py` — no changes (already catches client exceptions)
+- `providers.py` — `MenuProvider` protocol unchanged (no signature changes)
+- All existing parsing tests in `test_menu_client.py` — unaffected
+
+### New tests
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_retry_succeeds_on_second_attempt` | 500 then 200 returns data |
+| `test_retry_exhausted_raises` | 3x 500 raises `HTTPStatusError` |
+| `test_4xx_not_retried` | 404 raises immediately (1 request, not 4) |
+| `test_429_respects_retry_after` | 429 with `Retry-After: 1` header retries after delay |
+| `test_timeout_retried` | Timeout then 200 returns data |
+| `test_malformed_json_returns_empty` | Non-JSON response body returns `[]` |
+| `test_non_dict_response_returns_empty` | JSON array response returns `[]` |
+| `test_null_response_returns_empty` | JSON null response returns `[]` |
+| `test_search_malformed_json_returns_empty` | search_schools handles bad JSON |
+
+Existing tests `test_http_500_raises` and `test_timeout_raises` updated to pass `max_retries=0` so they keep their current assertion (immediate raise).
+
+### Error budget
+
+With 3 retries and delays of (1, 2, 4), worst case per request is 7 seconds. For 280 requests, if every request maxes out retries, total sync time = ~33 minutes. The Vercel function timeout is 60 seconds, but the engine already catches per-request failures — so individual timeouts don't kill the whole sync. The throttle adds 0.1s * 280 = 28 seconds baseline. Acceptable for a daily cron job.

--- a/src/lunchbox/sync/menu_client.py
+++ b/src/lunchbox/sync/menu_client.py
@@ -83,10 +83,20 @@ class SchoolCafeClient:
 
     BASE_URL = "https://webapis.schoolcafe.com/api"
 
-    def __init__(self, timeout: int = 30):
+    def __init__(
+        self,
+        timeout: int = 30,
+        max_retries: int = 3,
+        retry_delays: tuple[float, ...] = (1, 2, 4),
+        min_request_delay: float = 0.1,
+    ):
         self._client = httpx.Client(
             timeout=timeout, headers={"Accept": "application/json"}
         )
+        self._max_retries = max_retries
+        self._retry_delays = retry_delays
+        self._min_request_delay = min_request_delay
+        self._last_request_time = 0.0
 
     def get_daily_menu(
         self,

--- a/src/lunchbox/sync/menu_client.py
+++ b/src/lunchbox/sync/menu_client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from datetime import date
@@ -194,7 +195,16 @@ class SchoolCafeClient:
             f"{self.BASE_URL}/CalendarView/GetDailyMenuitemsByGrade",
             params=params,
         )
-        data = response.json()
+
+        try:
+            data = response.json()
+        except json.JSONDecodeError:
+            logger.warning("SchoolCafe returned invalid JSON for %s %s", school_id, menu_date)
+            return []
+
+        if not isinstance(data, dict):
+            logger.warning("SchoolCafe returned non-dict response: %s", type(data).__name__)
+            return []
 
         drift_warnings = _detect_drift(data)
         for warning in drift_warnings:

--- a/src/lunchbox/sync/menu_client.py
+++ b/src/lunchbox/sync/menu_client.py
@@ -101,6 +101,11 @@ class SchoolCafeClient:
         self._min_request_delay = min_request_delay
         self._last_request_time = 0.0
 
+    def _get_delay(self, attempt: int) -> float:
+        if attempt < len(self._retry_delays):
+            return self._retry_delays[attempt]
+        return self._retry_delays[-1]
+
     def _throttle(self) -> None:
         """Sleep if less than _min_request_delay since last request."""
         if self._min_request_delay <= 0:
@@ -125,11 +130,7 @@ class SchoolCafeClient:
             except httpx.TimeoutException as exc:
                 last_exc = exc
                 if attempt < self._max_retries:
-                    delay = (
-                        self._retry_delays[attempt]
-                        if attempt < len(self._retry_delays)
-                        else self._retry_delays[-1]
-                    )
+                    delay = self._get_delay(attempt)
                     logger.warning(
                         "Request timeout (attempt %d/%d), retrying in %.1fs",
                         attempt + 1,
@@ -149,23 +150,11 @@ class SchoolCafeClient:
                         try:
                             delay = min(float(retry_after), RETRY_AFTER_CAP)
                         except (ValueError, TypeError):
-                            delay = (
-                                self._retry_delays[attempt]
-                                if attempt < len(self._retry_delays)
-                                else self._retry_delays[-1]
-                            )
+                            delay = self._get_delay(attempt)
                     else:
-                        delay = (
-                            self._retry_delays[attempt]
-                            if attempt < len(self._retry_delays)
-                            else self._retry_delays[-1]
-                        )
+                        delay = self._get_delay(attempt)
                 elif 500 <= status < 600:
-                    delay = (
-                        self._retry_delays[attempt]
-                        if attempt < len(self._retry_delays)
-                        else self._retry_delays[-1]
-                    )
+                    delay = self._get_delay(attempt)
                 else:
                     # 4xx (not 429) — don't retry
                     raise

--- a/src/lunchbox/sync/menu_client.py
+++ b/src/lunchbox/sync/menu_client.py
@@ -1,7 +1,8 @@
 import json
 import logging
 import time
-from datetime import date
+from datetime import date, datetime, timezone
+from email.utils import parsedate_to_datetime
 
 import httpx
 
@@ -94,6 +95,8 @@ class SchoolCafeClient:
         retry_delays: tuple[float, ...] = (1, 2, 4),
         min_request_delay: float = 0.1,
     ):
+        if max_retries < 0:
+            raise ValueError(f"max_retries must be >= 0, got {max_retries}")
         self._client = httpx.Client(
             timeout=timeout, headers={"Accept": "application/json"}
         )
@@ -153,7 +156,20 @@ class SchoolCafeClient:
                         try:
                             delay = max(0, min(float(retry_after), RETRY_AFTER_CAP))
                         except (ValueError, TypeError):
-                            delay = self._get_delay(attempt)
+                            # Try HTTP-date format (RFC 7231)
+                            try:
+                                dt = parsedate_to_datetime(retry_after)
+                                delay = max(
+                                    0,
+                                    min(
+                                        (
+                                            dt - datetime.now(timezone.utc)
+                                        ).total_seconds(),
+                                        RETRY_AFTER_CAP,
+                                    ),
+                                )
+                            except (ValueError, TypeError):
+                                delay = self._get_delay(attempt)
                     else:
                         delay = self._get_delay(attempt)
                 elif 500 <= status < 600:

--- a/src/lunchbox/sync/menu_client.py
+++ b/src/lunchbox/sync/menu_client.py
@@ -103,6 +103,8 @@ class SchoolCafeClient:
         self._last_request_time = 0.0
 
     def _get_delay(self, attempt: int) -> float:
+        if not self._retry_delays:
+            return 0.0
         if attempt < len(self._retry_delays):
             return self._retry_delays[attempt]
         return self._retry_delays[-1]
@@ -149,7 +151,7 @@ class SchoolCafeClient:
                     retry_after = exc.response.headers.get("Retry-After")
                     if retry_after is not None:
                         try:
-                            delay = min(float(retry_after), RETRY_AFTER_CAP)
+                            delay = max(0, min(float(retry_after), RETRY_AFTER_CAP))
                         except (ValueError, TypeError):
                             delay = self._get_delay(attempt)
                     else:
@@ -257,10 +259,19 @@ class SchoolCafeClient:
             return []
 
         if not isinstance(districts, list) or not districts:
+            if districts:
+                logger.warning(
+                    "SchoolCafe returned non-list districts response: %s",
+                    type(districts).__name__,
+                )
             return []
 
         district_id = districts[0].get("ISDId")
         if not district_id:
+            logger.warning(
+                "SchoolCafe district missing ISDId, keys: %s",
+                list(districts[0].keys()),
+            )
             return []
 
         response = self._request(

--- a/src/lunchbox/sync/menu_client.py
+++ b/src/lunchbox/sync/menu_client.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from datetime import date
 
 import httpx
@@ -17,6 +18,8 @@ CATEGORY_ALIASES: dict[str, str] = {
     "milk": "Milk",
     "condiments": "Condiments",
 }
+
+RETRY_AFTER_CAP = 10
 
 
 def _extract_item_name(item) -> str | None:
@@ -98,6 +101,89 @@ class SchoolCafeClient:
         self._min_request_delay = min_request_delay
         self._last_request_time = 0.0
 
+    def _throttle(self) -> None:
+        """Sleep if less than _min_request_delay since last request."""
+        if self._min_request_delay <= 0:
+            return
+        now = time.monotonic()
+        elapsed = now - self._last_request_time
+        if elapsed < self._min_request_delay:
+            time.sleep(self._min_request_delay - elapsed)
+
+    def _request(self, url: str, **kwargs) -> httpx.Response:
+        """Make an HTTP GET with retry logic for transient failures."""
+        last_exc: Exception | None = None
+
+        for attempt in range(self._max_retries + 1):
+            self._throttle()
+            self._last_request_time = time.monotonic()
+
+            try:
+                response = self._client.get(url, **kwargs)
+                response.raise_for_status()
+                return response
+            except httpx.TimeoutException as exc:
+                last_exc = exc
+                if attempt < self._max_retries:
+                    delay = (
+                        self._retry_delays[attempt]
+                        if attempt < len(self._retry_delays)
+                        else self._retry_delays[-1]
+                    )
+                    logger.warning(
+                        "Request timeout (attempt %d/%d), retrying in %.1fs",
+                        attempt + 1,
+                        self._max_retries + 1,
+                        delay,
+                    )
+                    time.sleep(delay)
+                else:
+                    raise
+            except httpx.HTTPStatusError as exc:
+                last_exc = exc
+                status = exc.response.status_code
+
+                if status == 429:
+                    retry_after = exc.response.headers.get("Retry-After")
+                    if retry_after is not None:
+                        try:
+                            delay = min(float(retry_after), RETRY_AFTER_CAP)
+                        except (ValueError, TypeError):
+                            delay = (
+                                self._retry_delays[attempt]
+                                if attempt < len(self._retry_delays)
+                                else self._retry_delays[-1]
+                            )
+                    else:
+                        delay = (
+                            self._retry_delays[attempt]
+                            if attempt < len(self._retry_delays)
+                            else self._retry_delays[-1]
+                        )
+                elif 500 <= status < 600:
+                    delay = (
+                        self._retry_delays[attempt]
+                        if attempt < len(self._retry_delays)
+                        else self._retry_delays[-1]
+                    )
+                else:
+                    # 4xx (not 429) — don't retry
+                    raise
+
+                if attempt < self._max_retries:
+                    logger.warning(
+                        "HTTP %d (attempt %d/%d), retrying in %.1fs",
+                        status,
+                        attempt + 1,
+                        self._max_retries + 1,
+                        delay,
+                    )
+                    time.sleep(delay)
+                else:
+                    raise
+
+        raise last_exc  # type: ignore[misc]  # unreachable safety net
+
     def get_daily_menu(
         self,
         school_id: str,
@@ -115,11 +201,10 @@ class SchoolCafeClient:
             "PersonId": "",
         }
 
-        response = self._client.get(
+        response = self._request(
             f"{self.BASE_URL}/CalendarView/GetDailyMenuitemsByGrade",
             params=params,
         )
-        response.raise_for_status()
         data = response.json()
 
         drift_warnings = _detect_drift(data)
@@ -155,11 +240,10 @@ class SchoolCafeClient:
         return unique
 
     def search_schools(self, query: str) -> list[SchoolInfo]:
-        response = self._client.get(
+        response = self._request(
             f"{self.BASE_URL}/GetISDByShortName",
             params={"shortname": query},
         )
-        response.raise_for_status()
         districts = response.json()
 
         if not districts:
@@ -169,11 +253,10 @@ class SchoolCafeClient:
         if not district_id:
             return []
 
-        response = self._client.get(
+        response = self._request(
             f"{self.BASE_URL}/GetSchoolsList",
             params={"districtId": district_id},
         )
-        response.raise_for_status()
         schools = response.json()
 
         return [

--- a/src/lunchbox/sync/menu_client.py
+++ b/src/lunchbox/sync/menu_client.py
@@ -199,11 +199,15 @@ class SchoolCafeClient:
         try:
             data = response.json()
         except json.JSONDecodeError:
-            logger.warning("SchoolCafe returned invalid JSON for %s %s", school_id, menu_date)
+            logger.warning(
+                "SchoolCafe returned invalid JSON for %s %s", school_id, menu_date
+            )
             return []
 
         if not isinstance(data, dict):
-            logger.warning("SchoolCafe returned non-dict response: %s", type(data).__name__)
+            logger.warning(
+                "SchoolCafe returned non-dict response: %s", type(data).__name__
+            )
             return []
 
         drift_warnings = _detect_drift(data)
@@ -247,7 +251,9 @@ class SchoolCafeClient:
         try:
             districts = response.json()
         except json.JSONDecodeError:
-            logger.warning("SchoolCafe returned invalid JSON for districts query: %s", query)
+            logger.warning(
+                "SchoolCafe returned invalid JSON for districts query: %s", query
+            )
             return []
 
         if not isinstance(districts, list) or not districts:
@@ -265,11 +271,17 @@ class SchoolCafeClient:
         try:
             schools = response.json()
         except json.JSONDecodeError:
-            logger.warning("SchoolCafe returned invalid JSON for schools list: district %s", district_id)
+            logger.warning(
+                "SchoolCafe returned invalid JSON for schools list: district %s",
+                district_id,
+            )
             return []
 
         if not isinstance(schools, list):
-            logger.warning("SchoolCafe returned non-list schools response: %s", type(schools).__name__)
+            logger.warning(
+                "SchoolCafe returned non-list schools response: %s",
+                type(schools).__name__,
+            )
             return []
 
         return [

--- a/src/lunchbox/sync/menu_client.py
+++ b/src/lunchbox/sync/menu_client.py
@@ -243,9 +243,14 @@ class SchoolCafeClient:
             f"{self.BASE_URL}/GetISDByShortName",
             params={"shortname": query},
         )
-        districts = response.json()
 
-        if not districts:
+        try:
+            districts = response.json()
+        except json.JSONDecodeError:
+            logger.warning("SchoolCafe returned invalid JSON for districts query: %s", query)
+            return []
+
+        if not isinstance(districts, list) or not districts:
             return []
 
         district_id = districts[0].get("ISDId")
@@ -256,7 +261,16 @@ class SchoolCafeClient:
             f"{self.BASE_URL}/GetSchoolsList",
             params={"districtId": district_id},
         )
-        schools = response.json()
+
+        try:
+            schools = response.json()
+        except json.JSONDecodeError:
+            logger.warning("SchoolCafe returned invalid JSON for schools list: district %s", district_id)
+            return []
+
+        if not isinstance(schools, list):
+            logger.warning("SchoolCafe returned non-list schools response: %s", type(schools).__name__)
+            return []
 
         return [
             SchoolInfo(

--- a/tests/unit/test_menu_client_http.py
+++ b/tests/unit/test_menu_client_http.py
@@ -122,7 +122,9 @@ class TestResponseValidation:
             return_value=httpx.Response(200, content=b"not json at all")
         )
         with SchoolCafeClient(max_retries=0) as client:
-            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+            items = client.get_daily_menu(
+                "s1", date(2026, 3, 16), "Lunch", "Trad", "05"
+            )
         assert items == []
 
     @respx.mock
@@ -131,7 +133,9 @@ class TestResponseValidation:
             return_value=httpx.Response(200, json=["not", "a", "dict"])
         )
         with SchoolCafeClient(max_retries=0) as client:
-            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+            items = client.get_daily_menu(
+                "s1", date(2026, 3, 16), "Lunch", "Trad", "05"
+            )
         assert items == []
 
     @respx.mock
@@ -140,7 +144,9 @@ class TestResponseValidation:
             return_value=httpx.Response(200, json=None)
         )
         with SchoolCafeClient(max_retries=0) as client:
-            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+            items = client.get_daily_menu(
+                "s1", date(2026, 3, 16), "Lunch", "Trad", "05"
+            )
         assert items == []
 
     @respx.mock
@@ -205,8 +211,12 @@ class TestRetry:
             httpx.Response(200, json=data),
         ]
 
-        with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
-            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+        with SchoolCafeClient(
+            max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0
+        ) as client:
+            items = client.get_daily_menu(
+                "s1", date(2026, 3, 16), "Lunch", "Trad", "05"
+            )
 
         assert len(items) > 0
         assert route.call_count == 2
@@ -220,8 +230,12 @@ class TestRetry:
             httpx.Response(200, json=data),
         ]
 
-        with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
-            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+        with SchoolCafeClient(
+            max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0
+        ) as client:
+            items = client.get_daily_menu(
+                "s1", date(2026, 3, 16), "Lunch", "Trad", "05"
+            )
 
         assert len(items) > 0
         assert route.call_count == 2

--- a/tests/unit/test_menu_client_http.py
+++ b/tests/unit/test_menu_client_http.py
@@ -137,6 +137,36 @@ class TestRetry:
         assert route.call_count == 2
 
     @respx.mock
+    def test_429_respects_retry_after(self, schoolcafe_fixture):
+        data = schoolcafe_fixture("normal_lunch")
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade")
+        route.side_effect = [
+            httpx.Response(429, headers={"Retry-After": "0"}),
+            httpx.Response(200, json=data),
+        ]
+
+        with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert len(items) > 0
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_429_without_retry_after(self, schoolcafe_fixture):
+        data = schoolcafe_fixture("normal_lunch")
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade")
+        route.side_effect = [
+            httpx.Response(429),  # no Retry-After header
+            httpx.Response(200, json=data),
+        ]
+
+        with SchoolCafeClient(max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert len(items) > 0
+        assert route.call_count == 2
+
+    @respx.mock
     def test_retry_exhausted_raises(self):
         route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
             return_value=httpx.Response(500)

--- a/tests/unit/test_menu_client_http.py
+++ b/tests/unit/test_menu_client_http.py
@@ -10,6 +10,27 @@ from lunchbox.sync.menu_client import SchoolCafeClient
 BASE_URL = "https://webapis.schoolcafe.com/api"
 
 
+class TestClientConfig:
+    def test_default_constructor(self):
+        client = SchoolCafeClient()
+        assert client._max_retries == 3
+        assert client._retry_delays == (1, 2, 4)
+        assert client._min_request_delay == 0.1
+        assert client._last_request_time == 0.0
+        client.close()
+
+    def test_custom_constructor(self):
+        client = SchoolCafeClient(
+            max_retries=5,
+            retry_delays=(0.5, 1.0),
+            min_request_delay=0.5,
+        )
+        assert client._max_retries == 5
+        assert client._retry_delays == (0.5, 1.0)
+        assert client._min_request_delay == 0.5
+        client.close()
+
+
 class TestGetDailyMenu:
     @respx.mock
     def test_successful_fetch(self, schoolcafe_fixture):

--- a/tests/unit/test_menu_client_http.py
+++ b/tests/unit/test_menu_client_http.py
@@ -115,6 +115,66 @@ class TestSearchSchools:
         assert result == []
 
 
+class TestResponseValidation:
+    @respx.mock
+    def test_malformed_json_returns_empty(self):
+        respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            return_value=httpx.Response(200, content=b"not json at all")
+        )
+        with SchoolCafeClient(max_retries=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+        assert items == []
+
+    @respx.mock
+    def test_non_dict_response_returns_empty(self):
+        respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            return_value=httpx.Response(200, json=["not", "a", "dict"])
+        )
+        with SchoolCafeClient(max_retries=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+        assert items == []
+
+    @respx.mock
+    def test_null_response_returns_empty(self):
+        respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            return_value=httpx.Response(200, json=None)
+        )
+        with SchoolCafeClient(max_retries=0) as client:
+            items = client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+        assert items == []
+
+    @respx.mock
+    def test_search_malformed_json_returns_empty(self):
+        respx.get(f"{BASE_URL}/GetISDByShortName").mock(
+            return_value=httpx.Response(200, content=b"not json")
+        )
+        with SchoolCafeClient(max_retries=0) as client:
+            result = client.search_schools("test")
+        assert result == []
+
+    @respx.mock
+    def test_search_non_list_districts_returns_empty(self):
+        respx.get(f"{BASE_URL}/GetISDByShortName").mock(
+            return_value=httpx.Response(200, json={"error": "bad request"})
+        )
+        with SchoolCafeClient(max_retries=0) as client:
+            result = client.search_schools("test")
+        assert result == []
+
+    @respx.mock
+    def test_search_non_list_schools_returns_empty(self, schoolcafe_fixture):
+        districts = schoolcafe_fixture("search_districts")
+        respx.get(f"{BASE_URL}/GetISDByShortName").mock(
+            return_value=httpx.Response(200, json=districts)
+        )
+        respx.get(f"{BASE_URL}/GetSchoolsList").mock(
+            return_value=httpx.Response(200, json={"error": "bad"})
+        )
+        with SchoolCafeClient(max_retries=0) as client:
+            result = client.search_schools("springfield")
+        assert result == []
+
+
 class TestRetry:
     @respx.mock
     def test_retry_succeeds_on_second_attempt(self, schoolcafe_fixture):

--- a/tests/unit/test_menu_client_http.py
+++ b/tests/unit/test_menu_client_http.py
@@ -68,7 +68,7 @@ class TestGetDailyMenu:
             return_value=httpx.Response(500)
         )
 
-        with SchoolCafeClient() as client:
+        with SchoolCafeClient(max_retries=0) as client:
             with pytest.raises(httpx.HTTPStatusError):
                 client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
 
@@ -78,7 +78,7 @@ class TestGetDailyMenu:
             side_effect=httpx.TimeoutException("timed out")
         )
 
-        with SchoolCafeClient() as client:
+        with SchoolCafeClient(max_retries=0) as client:
             with pytest.raises(httpx.TimeoutException):
                 client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
 
@@ -113,3 +113,73 @@ class TestSearchSchools:
             result = client.search_schools("nonexistent")
 
         assert result == []
+
+
+class TestRetry:
+    @respx.mock
+    def test_retry_succeeds_on_second_attempt(self, schoolcafe_fixture):
+        data = schoolcafe_fixture("normal_lunch")
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            side_effect=[
+                httpx.Response(500),
+                httpx.Response(200, json=data),
+            ]
+        )
+
+        with SchoolCafeClient(
+            max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0
+        ) as client:
+            items = client.get_daily_menu(
+                "s1", date(2026, 3, 16), "Lunch", "Trad", "05"
+            )
+
+        assert len(items) > 0
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_retry_exhausted_raises(self):
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            return_value=httpx.Response(500)
+        )
+
+        with SchoolCafeClient(
+            max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0
+        ) as client:
+            with pytest.raises(httpx.HTTPStatusError):
+                client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert route.call_count == 4
+
+    @respx.mock
+    def test_4xx_not_retried(self):
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            return_value=httpx.Response(404)
+        )
+
+        with SchoolCafeClient(
+            max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0
+        ) as client:
+            with pytest.raises(httpx.HTTPStatusError):
+                client.get_daily_menu("s1", date(2026, 3, 16), "Lunch", "Trad", "05")
+
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_timeout_retried(self, schoolcafe_fixture):
+        data = schoolcafe_fixture("normal_lunch")
+        route = respx.get(f"{BASE_URL}/CalendarView/GetDailyMenuitemsByGrade").mock(
+            side_effect=[
+                httpx.TimeoutException("timed out"),
+                httpx.Response(200, json=data),
+            ]
+        )
+
+        with SchoolCafeClient(
+            max_retries=3, retry_delays=(0, 0, 0), min_request_delay=0
+        ) as client:
+            items = client.get_daily_menu(
+                "s1", date(2026, 3, 16), "Lunch", "Trad", "05"
+            )
+
+        assert len(items) > 0
+        assert route.call_count == 2


### PR DESCRIPTION
## Summary
- Add **retry with exponential backoff** for 5xx and timeout errors (up to 3 retries, delays 1/2/4s)
- Add **rate limiting** — 100ms throttle between requests, respect `Retry-After` header on 429 (capped at 10s)
- Add **response validation** — handle malformed JSON, non-dict/non-list responses gracefully in both `get_daily_menu()` and `search_schools()`
- Centralize all HTTP concerns in a new `_request()` method

## Test plan
- [x] 20 new/updated tests covering retry, 429, validation, and constructor config
- [x] All 46 unit tests pass (31 DB-dependent skip as expected)
- [x] Ruff lint + format clean

Closes #59, closes #60, closes #61